### PR TITLE
Proposing new TeX icon for LaTeX/TeX editors

### DIFF
--- a/apps/scalable/latexila.svg
+++ b/apps/scalable/latexila.svg
@@ -1,1 +1,1 @@
-accessories-text-editor.svg
+texmaker.svg

--- a/apps/scalable/texmaker.svg
+++ b/apps/scalable/texmaker.svg
@@ -1,1 +1,194 @@
-accessories-text-editor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="texmaker.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.835812"
+     inkscape:cx="9.0533252"
+     inkscape:cy="22.528949"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4089"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="836"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1">
+    <sodipodi:guide
+       position="8.9999928,39"
+       orientation="30,0"
+       id="guide3295" />
+    <sodipodi:guide
+       position="8.9999928,9"
+       orientation="0,30"
+       id="guide3297" />
+    <sodipodi:guide
+       position="38.999993,9"
+       orientation="-30,0"
+       id="guide3299" />
+    <sodipodi:guide
+       position="38.999993,39"
+       orientation="0,-30"
+       id="guide3301" />
+    <sodipodi:guide
+       position="7.000008,44"
+       orientation="40,0"
+       id="guide3315" />
+    <sodipodi:guide
+       position="7.000008,4"
+       orientation="0,33.999985"
+       id="guide3317" />
+    <sodipodi:guide
+       position="40.999993,4"
+       orientation="-40,0"
+       id="guide3319" />
+    <sodipodi:guide
+       position="40.999993,44"
+       orientation="0,-33.999985"
+       id="guide3321" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-180.23661,-689.8125)">
+    <g
+       id="g4089">
+      <rect
+         y="697.81195"
+         x="187.23662"
+         height="36"
+         width="33.999985"
+         id="rect853"
+         style="fill:#f3dfc6;fill-opacity:1;stroke:none" />
+      <rect
+         y="703.15045"
+         x="187.2366"
+         height="0.30769232"
+         width="34"
+         id="rect859"
+         style="fill:#d19e69;fill-opacity:1;stroke:none" />
+      <rect
+         style="fill:#d19e69;fill-opacity:1;stroke:none"
+         id="rect861"
+         width="34"
+         height="0.30769232"
+         x="187.2366"
+         y="708.65613" />
+      <rect
+         y="714.16174"
+         x="187.2366"
+         height="0.30769232"
+         width="34"
+         id="rect863"
+         style="fill:#d19e69;fill-opacity:1;stroke:none" />
+      <rect
+         y="693.81226"
+         x="189.2366"
+         height="5.000001"
+         width="3"
+         id="rect870"
+         style="fill:#151718;fill-opacity:1;stroke:none" />
+      <rect
+         style="fill:#151718;fill-opacity:1;stroke:none"
+         id="rect872"
+         width="3"
+         height="5.000001"
+         x="198.2366"
+         y="693.81226" />
+      <rect
+         y="693.81226"
+         x="207.2366"
+         height="5.000001"
+         width="3"
+         id="rect874"
+         style="fill:#151718;fill-opacity:1;stroke:none" />
+      <rect
+         style="fill:#151718;fill-opacity:1;stroke:none"
+         id="rect876"
+         width="3"
+         height="5.000001"
+         x="216.2366"
+         y="693.81226" />
+      <rect
+         style="fill:#d19e69;fill-opacity:1;stroke:none"
+         id="rect889"
+         width="34"
+         height="0.30769232"
+         x="187.2366"
+         y="719.66742" />
+      <rect
+         y="725.17303"
+         x="187.2366"
+         height="0.30769232"
+         width="34"
+         id="rect891"
+         style="fill:#d19e69;fill-opacity:1;stroke:none" />
+      <rect
+         transform="matrix(0,-1,1,0,0,0)"
+         style="fill:#e68273;fill-opacity:1;stroke:none"
+         id="rect895"
+         width="36"
+         height="0.5"
+         x="-733.8125"
+         y="194.9866" />
+      <g
+         id="g3044"
+         transform="matrix(0.0295302,0,0,0.02940419,189.10057,708.58973)"
+         style="fill:#151718;fill-opacity:1">
+        <path
+           id="path14"
+           d="M 364.09375,23.888705 H 14.81625 L 4.6066,157.66443 h 10.869125 c 7.816,-100.19135 16.4136,-117.7285 110.205605,-117.7285 10.86912,4.89e-4 28.52839,4.89e-4 33.38897,4.89e-4 11.55302,1.808183 11.55302,9.158886 11.55302,23.081136 V 392.26656 c 0,21.86037 -1.83187,28.5284 -52.78242,28.5284 h -17.17077 v 14.60615 c 29.01689,-0.56178 59.25504,-1.14798 88.93142,-1.14798 29.57867,0 59.91452,0.5862 88.907,1.14798 v -14.60615 h -16.87768 c -50.19337,0 -52.00082,-6.66803 -52.00082,-28.5284 V 63.017555 c 0,-13.360475 0,-20.613967 10.89355,-23.081136 h 33.19357 c 92.54633,0 101.608,17.438961 109.42401,117.728501 h 10.89355"
+           inkscape:connector-curvature="0"
+           style="fill:#151718;fill-opacity:1" />
+        <path
+           id="path16"
+           d="M 667.5988,414.3215 H 656.72967 C 643.4669,504.0101 635.6509,552.7624 529.2556,552.7624 h -83.94873 c -24.15632,0 -25.3043,-3.05313 -25.3043,-23.86322 V 359.82932 h 57.0568 c 57.0568,0 62.50358,20.9078 62.50358,71.95605 h 9.72115 V 274.43952 h -9.72115 c 0,50.19338 -5.44677,70.71038 -62.50358,70.71038 H 420.00258 V 195.25368 c 0,-20.41931 1.14797,-23.47243 25.3043,-23.47243 h 82.70305 c 93.5966,0 104.49015,37.19927 112.96562,117.16673 H 651.8691 L 637.36065,155.17225 H 331.09558 v 16.609 c 42.84144,0 49.70487,0 49.70487,27.18502 v 326.4157 c 0,27.18503 -6.76572,27.18503 -49.70487,27.18503 v 14.60615 h 314.76497"
+           inkscape:connector-curvature="0"
+           style="fill:#151718;fill-opacity:1" />
+        <path
+           id="path18"
+           d="M 830.6601,206.5136 920.1533,77.134375 c 8.96397,-12.701 27.18503,-38.83575 76.81663,-39.495225 V 23.033 c -13.84898,1.147902 -36.8329,1.147902 -51.34135,1.147902 -19.9308,0 -44.7466,0 -59.81683,-1.147902 v 14.606639 c 19.36903,1.806961 24.1319,13.921761 24.1319,23.667336 0,7.2298 -2.95542,12.1148 -7.25422,18.12335 L 822.8441,195.25368 733.3509,64.2624 c -4.2011,-6.59475 -4.7873,-8.4999 -4.7873,-10.30735 0,-5.446775 6.59475,-15.753392 26.62325,-16.315411 V 23.033 c -19.36902,1.147902 -48.9477,1.147902 -68.8785,1.147902 -15.65643,0 -45.89458,0 -60.50072,-1.147902 v 14.606639 c 33.21799,0 44.08712,1.246407 57.44759,20.028011 l 116.67823,171.3658 -105.2229,153.70653 c -25.96378,37.59007 -65.2636,38.24955 -76.81663,38.24955 v 14.60614 c 13.82455,-1.14797 36.8329,-1.14797 51.34135,-1.14797 16.3159,0 44.74661,0 59.81683,1.14797 v -14.60614 c -18.70955,-1.80746 -24.1319,-13.92226 -24.1319,-23.66783 0,-7.816 2.95542,-12.1148 6.00855,-16.4136 l 96.74742,-141.20093 105.2229,154.6591 c 4.76288,6.69246 4.76288,8.4999 4.76288,10.30736 0,4.76287 -5.42235,15.16792 -26.59882,16.4136 v 14.60614 c 19.36902,-1.14797 48.94769,-1.14797 68.8785,-1.14797 15.65642,0 45.89457,0 60.57397,1.14797 v -14.60614 c -38.73803,0 -44.84427,-2.95543 -56.86138,-20.0285"
+           inkscape:connector-curvature="0"
+           style="fill:#151718;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
I've made a sightly change on default text editor icon to clarify and distinct the normal plain text editors (like gedit, kate and others) and LaTeX editors (like TexMaker and latexila)
