### PR TITLE
Create folder-drag-accept.svg

### DIFF
--- a/places/scalable/folder-drag-accept.svg
+++ b/places/scalable/folder-drag-accept.svg
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg865"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="folder-drag-accept.svg">
+  <defs
+     id="defs867" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-34.316087"
+     inkscape:cy="20.598333"
+     inkscape:document-units="px"
+     inkscape:current-layer="folderLayer"
+     showgrid="false"
+     inkscape:window-width="1024"
+     inkscape:window-height="535"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     showguides="true">
+    <sodipodi:guide
+       position="0,39.000017"
+       orientation="30,0"
+       id="guide4110" />
+    <sodipodi:guide
+       position="30,39.000017"
+       orientation="0,-30"
+       id="guide4116" />
+    <sodipodi:guide
+       position="30,9.0000174"
+       orientation="0,18"
+       id="guide4120" />
+    <sodipodi:guide
+       position="48,9.0000174"
+       orientation="-30,0"
+       id="guide4122" />
+    <sodipodi:guide
+       position="48,39.000017"
+       orientation="0,-18"
+       id="guide4124" />
+    <sodipodi:guide
+       position="4,41.000017"
+       orientation="34,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="22,41.000017"
+       orientation="0,-18"
+       id="guide4170" />
+    <sodipodi:guide
+       position="6,37.0002"
+       orientation="27.999817,0"
+       id="guide4174" />
+    <sodipodi:guide
+       position="6,9.0003836"
+       orientation="0,35.999992"
+       id="guide4176" />
+    <sodipodi:guide
+       position="41.999992,9.0003836"
+       orientation="-27.999817,0"
+       id="guide4178" />
+    <sodipodi:guide
+       position="41.999992,37.0002"
+       orientation="0,-35.999992"
+       id="guide4180" />
+    <sodipodi:guide
+       position="14,31.000017"
+       orientation="20,0"
+       id="guide4221" />
+    <sodipodi:guide
+       position="34,11.000017"
+       orientation="-20,0"
+       id="guide4225" />
+    <sodipodi:guide
+       position="34,31.000017"
+       orientation="0,-20"
+       id="guide4227" />
+    <sodipodi:guide
+       position="14,31.000017"
+       orientation="11,0"
+       id="guide4412" />
+    <sodipodi:guide
+       position="14,20.000017"
+       orientation="0,11"
+       id="guide4414" />
+    <sodipodi:guide
+       position="25,20.000017"
+       orientation="-11,0"
+       id="guide4416" />
+    <sodipodi:guide
+       position="25,31.000017"
+       orientation="0,-11"
+       id="guide4418" />
+    <sodipodi:guide
+       position="25,20.000017"
+       orientation="9,0"
+       id="guide4420" />
+    <sodipodi:guide
+       position="25,11.000017"
+       orientation="0,9"
+       id="guide4422" />
+    <sodipodi:guide
+       position="34,11.000017"
+       orientation="-9,0"
+       id="guide4424" />
+    <sodipodi:guide
+       position="34,20.000017"
+       orientation="0,-9"
+       id="guide4426" />
+    <sodipodi:guide
+       position="23.000001,35.000017"
+       orientation="-1.9999999,0"
+       id="guide4068" />
+    <sodipodi:guide
+       position="23.000001,37.000017"
+       orientation="0,2"
+       id="guide4070" />
+    <sodipodi:guide
+       position="25,37.000017"
+       orientation="1.9999999,0"
+       id="guide4072" />
+    <sodipodi:guide
+       position="25,35.000017"
+       orientation="0,-2"
+       id="guide4074" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata870">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="folderLayer"
+     inkscape:label="folder">
+    <rect
+       y="6.9996953"
+       x="4"
+       height="10"
+       width="18"
+       id="folderTab"
+       style="fill:#34495d;fill-opacity:1;stroke:none" />
+    <rect
+       style="fill:#34495d;fill-opacity:1;stroke:none"
+       id="folderBackground"
+       width="40"
+       height="30"
+       x="4"
+       y="9" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       id="folderPaper"
+       width="35.999992"
+       height="27.999756"
+       x="6"
+       y="10.9998" />
+    <rect
+       y="27.999992"
+       x="2"
+       height="13"
+       width="43.999996"
+       id="folderFront"
+       style="fill:#1abc9c;fill-opacity:1;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
the folder-drag-accept.svg icon is missing. So I create it. When you drag a file to a folder but without dropping the file into the folder, the folder icon should change by creating the illusion that the folder is opened to receive the file. Is this open folder that I leave here.

I hope you approve it.
