### PR TITLE
Added min & max size params for actions/symbolic icons

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -18,6 +18,8 @@ MaxSize=96
 Size=16
 Context=Actions
 Type=Scalable
+MinSize=16
+MaxSize=96
 
 [apps/scalable]
 Size=512


### PR DESCRIPTION
The icons placed in actions/symbolic were rendered in 16x16 resolution even though the icons were SVG. To enable proper scaling, the MaxSize and MinSize parameters were introduced.

In the image below you can see the view-grid-symbolic.svg icon used as the 'Show Applications' button in Gnome 3 dock. On the right you can see the image after a fix.
![fix](https://cloud.githubusercontent.com/assets/2813061/4940402/3e7f8b9a-65da-11e4-8215-cd9de950bb5e.png)

Keep up the good work, your theme is gorgeous.
