### PR TITLE
Merged missing icons into Lüv Dark from Lüv

### DIFF
--- a/Lüv Dark/actions/symbolic/action-unavailable-symbolic.svg
+++ b/Lüv Dark/actions/symbolic/action-unavailable-symbolic.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="action-unavailable-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="962"
+     id="namedview10"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="9.6766978"
+     inkscape:cy="8.2903433"
+     inkscape:window-x="-4"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4143" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4149" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4151" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4153" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4155" />
+    <sodipodi:guide
+       position="2,14"
+       orientation="12,0"
+       id="guide4157" />
+    <sodipodi:guide
+       position="2,2"
+       orientation="0,12"
+       id="guide4159" />
+    <sodipodi:guide
+       position="14,2"
+       orientation="-12,0"
+       id="guide4161" />
+    <sodipodi:guide
+       position="14,14"
+       orientation="0,-12"
+       id="guide4163" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 8 2 C 4.676 2 2 4.676 2 8 C 2 11.324 4.676 14 8 14 C 11.324 14 14 11.324 14 8 C 14 4.676 11.324 2 8 2 z M 7.4882812 3.0253906 C 7.4921304 3.0250021 7.4961482 3.0257705 7.5 3.0253906 A 5 5 0 0 0 7.0058594 3.0996094 C 7.1639802 3.0679307 7.3250516 3.0418685 7.4882812 3.0253906 z M 8 4 A 4 4 0 0 1 10.025391 4.5605469 L 4.5585938 10.027344 A 4 4 0 0 1 4 8 A 4 4 0 0 1 8 4 z M 11.441406 5.9726562 A 4 4 0 0 1 12 8 A 4 4 0 0 1 8 12 A 4 4 0 0 1 5.9746094 11.439453 L 11.441406 5.9726562 z "
+     id="rect4165" />
+</svg>

--- a/Lüv Dark/actions/symbolic/bookmark-add-symbolic.svg
+++ b/Lüv Dark/actions/symbolic/bookmark-add-symbolic.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="bookmark-add-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10000"
+     guidetolerance="10000"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="962"
+     id="namedview10"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:zoom="45.254834"
+     inkscape:cx="6.9338438"
+     inkscape:cy="7.4266576"
+     inkscape:window-x="-4"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4143" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4166" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4168" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4170" />
+    <sodipodi:guide
+       position="2,14"
+       orientation="12,0"
+       id="guide4172" />
+    <sodipodi:guide
+       position="2,2"
+       orientation="0,12"
+       id="guide4174" />
+    <sodipodi:guide
+       position="14,2"
+       orientation="-12,0"
+       id="guide4176" />
+    <sodipodi:guide
+       position="14,14"
+       orientation="0,-12"
+       id="guide4178" />
+  </sodipodi:namedview>
+  <path
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+     d="M 3 2 L 3 4 L 3 14 L 3.0058594 14 L 3.8378906 13.498047 L 5 12.800781 L 5 12.794922 L 7 11.587891 L 7 11.601562 L 7.5 11.300781 L 7.5 11.289062 L 8 10.988281 L 8 8.6484375 L 7.5 8.9511719 L 7 9.2539062 L 5 10.460938 L 5 4 L 7.5 4 L 8.5820312 4 L 11 4 L 11 7 L 13 7 L 13 4 L 13 2 L 8.5820312 2 L 7.5 2 L 3 2 z "
+     id="path4194" />
+  <rect
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.09544504;stroke-opacity:1"
+     id="rect4189"
+     width="2"
+     height="5.999999"
+     x="11"
+     y="7.9999967" />
+  <rect
+     y="-15"
+     x="9.9999962"
+     height="5.999999"
+     width="2"
+     id="rect4193"
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.09544504;stroke-opacity:1"
+     transform="rotate(90)" />
+</svg>

--- a/Lüv Dark/actions/symbolic/bookmark-new-symbolic.svg
+++ b/Lüv Dark/actions/symbolic/bookmark-new-symbolic.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="bookmark-new-symbolic.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10000"
+     guidetolerance="10000"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="962"
+     id="namedview8"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="6.8286978"
+     inkscape:cy="10.034671"
+     inkscape:window-x="-4"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4147" />
+    <sodipodi:guide
+       position="7.5,14"
+       orientation="0,-4.5"
+       id="guide4200" />
+    <sodipodi:guide
+       position="3,14"
+       orientation="2,0"
+       id="guide4202" />
+    <sodipodi:guide
+       position="3,12"
+       orientation="10,0"
+       id="guide4204" />
+    <sodipodi:guide
+       position="3,2"
+       orientation="0,0.00586"
+       id="guide4206" />
+    <sodipodi:guide
+       position="3.00586,2"
+       orientation="-0.501953,0.8320306"
+       id="guide4208" />
+    <sodipodi:guide
+       position="5,3.199219"
+       orientation="-0.0059,0"
+       id="guide4212" />
+    <sodipodi:guide
+       position="7.5,4.699219"
+       orientation="-2.3496091,0"
+       id="guide4220" />
+    <sodipodi:guide
+       position="7.5,7.0488281"
+       orientation="0.3027343,-0.5"
+       id="guide4222" />
+    <sodipodi:guide
+       position="5,5.539062"
+       orientation="-6.460938,0"
+       id="guide4226" />
+    <sodipodi:guide
+       position="5,12"
+       orientation="0,2.5"
+       id="guide4228" />
+    <sodipodi:guide
+       position="7.5,12"
+       orientation="-2,0"
+       id="guide4230" />
+    <sodipodi:guide
+       position="8.5,14"
+       orientation="2,0"
+       id="guide4232" />
+    <sodipodi:guide
+       position="8.5,12"
+       orientation="0,2.5"
+       id="guide4234" />
+    <sodipodi:guide
+       position="11,12"
+       orientation="3,0"
+       id="guide4236" />
+    <sodipodi:guide
+       position="11,9"
+       orientation="3.460938,0"
+       id="guide4238" />
+    <sodipodi:guide
+       position="11,5.539062"
+       orientation="-1.5097661,-2.5"
+       id="guide4240" />
+    <sodipodi:guide
+       position="8.5,7.0488281"
+       orientation="2.3496091,0"
+       id="guide4242" />
+    <sodipodi:guide
+       position="8.511719,4.707019"
+       orientation="2.707019,4.488281"
+       id="guide4246" />
+    <sodipodi:guide
+       position="13,2"
+       orientation="-7,0"
+       id="guide4248" />
+    <sodipodi:guide
+       position="13,9"
+       orientation="-3,0"
+       id="guide4250" />
+    <sodipodi:guide
+       position="13,12"
+       orientation="-2,0"
+       id="guide4252" />
+    <sodipodi:guide
+       position="13,14"
+       orientation="0,-4.5"
+       id="guide4254" />
+  </sodipodi:namedview>
+  <path
+     style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+     d="M 3 2 L 3 4 L 3 14 L 3.0058594 14 L 3.8378906 13.498047 L 5 12.800781 L 5 12.794922 L 7 11.587891 L 7 11.601562 L 7.5 11.300781 L 7.5 11.289062 L 8.0019531 10.986328 L 8.5 11.285156 L 8.5 11.300781 L 8.5117188 11.292969 L 13 14 L 13 7 L 13 4 L 13 2 L 8.5820312 2 L 7.5 2 L 3 2 z M 5 4 L 7.5 4 L 8.5820312 4 L 11 4 L 11 7 L 11 10.460938 L 8.5 8.9511719 L 8 8.6484375 L 7.5 8.9511719 L 7 9.2539062 L 5 10.460938 L 5 4 z "
+     id="path4194" />
+</svg>

--- a/Lüv Dark/actions/symbolic/browser-download-symbolic.svg
+++ b/Lüv Dark/actions/symbolic/browser-download-symbolic.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="browser-download-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10000"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="962"
+     id="namedview10"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     showborder="true"
+     borderlayer="true"
+     inkscape:zoom="41.7193"
+     inkscape:cx="8.7664211"
+     inkscape:cy="6.5537056"
+     inkscape:window-x="-4"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4143" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4163" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4165" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4169" />
+    <sodipodi:guide
+       position="2,14"
+       orientation="12,0"
+       id="guide4171" />
+    <sodipodi:guide
+       position="2,2"
+       orientation="0,12"
+       id="guide4173" />
+    <sodipodi:guide
+       position="14,2"
+       orientation="-12,0"
+       id="guide4175" />
+    <sodipodi:guide
+       position="14,14"
+       orientation="0,-12"
+       id="guide4177" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#bebebe;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+     d="M 4 2 L 1 5 L 1 14 L 3 14 L 10 14 L 10 12 L 10 2 L 8 2 L 4 2 z M 5 4 L 8 4 L 8 12 L 3 12 L 3 6 L 5 6 L 5 4 z M 12 8 L 12 12 L 11 12 L 13 14 L 15 12 L 14 12 L 14 8 L 12 8 z "
+     id="path4217" />
+</svg>

--- a/Lüv Dark/actions/symbolic/call-end-symbolic.svg
+++ b/Lüv Dark/actions/symbolic/call-end-symbolic.svg
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91pre2 r"
+   sodipodi:docname="call-end-symbolic.svg">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12">
+    <linearGradient
+       id="linearGradient3758">
+      <stop
+         id="stop3760"
+         style="stop-color:#c00000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3762"
+         style="stop-color:#ff7e7e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="672"
+     id="namedview10"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-16.616348"
+     inkscape:cy="12.829716"
+     inkscape:window-x="-4"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4143" />
+    <sodipodi:guide
+       position="0,16"
+       orientation="16,0"
+       id="guide4149" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,16"
+       id="guide4151" />
+    <sodipodi:guide
+       position="16,0"
+       orientation="-16,0"
+       id="guide4153" />
+    <sodipodi:guide
+       position="16,16"
+       orientation="0,-16"
+       id="guide4155" />
+    <sodipodi:guide
+       position="2,14"
+       orientation="12,0"
+       id="guide4157" />
+    <sodipodi:guide
+       position="2,2"
+       orientation="0,12"
+       id="guide4159" />
+    <sodipodi:guide
+       position="14,6"
+       orientation="-12,0"
+       id="guide4161" />
+    <sodipodi:guide
+       position="14,14"
+       orientation="0,-12"
+       id="guide4163" />
+  </sodipodi:namedview>
+  <path
+     style="color:#000000;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ef2929;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 4 2 L 4 14 L 12 14 L 12 2 L 4 2 z M 5 3 L 7 3 L 7 4 L 9 4 L 9 3 L 11 3 L 11 11 L 5 11 L 5 3 z M 7 12 L 9 12 L 9 13 L 7 13 L 7 12 z "
+     id="rect4165" />
+</svg>

--- a/Lüv Dark/apps/48/system-file-manager.svg
+++ b/Lüv Dark/apps/48/system-file-manager.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created using Karbon, part of Calligra: http://www.calligra.org/karbon -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-file-manager.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10000"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     id="namedview10"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="11.313708"
+     inkscape:cx="47.55864"
+     inkscape:cy="19.968519"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4141"
+       originx="20px"
+       originy="0px" />
+    <sodipodi:guide
+       position="0,48"
+       orientation="48,0"
+       id="guide4147" />
+    <sodipodi:guide
+       position="48,0"
+       orientation="-48,0"
+       id="guide4151" />
+    <sodipodi:guide
+       position="48,48"
+       orientation="0,-48"
+       id="guide4153" />
+    <sodipodi:guide
+       position="4,37"
+       orientation="40,0"
+       id="guide4219" />
+    <sodipodi:guide
+       position="6.9999962,3.999959"
+       orientation="0,34"
+       id="guide4221" />
+    <sodipodi:guide
+       position="44,32"
+       orientation="-29,0"
+       id="guide4223" />
+    <sodipodi:guide
+       position="29.999996,43.999958"
+       orientation="0,-23"
+       id="guide4227" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4190"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4200"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,129.00027,-75.333217)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4208"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,11.999835,155.33339)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Layer 1">
+    <path
+       style="opacity:0.7;fill:url(#radialGradient4200);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 44 42 L 44 46 L 45 46 C 46.108 46 47 45.108 47 44 L 47 42 L 44 42 z "
+       id="path4174" />
+    <path
+       style="opacity:0.7;fill:url(#linearGradient4190);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 4 42 L 4 46 L 44 46 L 44 42 L 4 42 z "
+       id="path4169" />
+    <path
+       style="opacity:0.7;fill:url(#radialGradient4208);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1 42 L 1 44 C 1 45.108 1.892 46 3 46 L 4 46 L 4 42 L 1 42 z "
+       id="rect4157" />
+    <path
+       style="opacity:1;fill:#ebb10f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       d="m 15,8.99997 0,3 0,10 0,4.00003 32,0 0,-5.00003 0,-9 c 0,-1.66199 -1.33803,-3.0075498 -3,-3 l -22,0 -4,0 z"
+       id="rect4161-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccssccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#e8e5dc;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21,11 22,0 c 1.108,0 2,0.892 2,2 l 0,3 c 0,1.108 -0.892,2 -2,2 l -22,0 c -1.108,0 -2,-0.892 -2,-2 l 0,-3 c 0,-1.108 0.892,-2 2,-2 z"
+       id="rect4188" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#fffbec;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21,12 22,0 c 0.554,0 1,0.446 1,1 l 0,4 c 0,0.554 -0.446,1 -1,1 l -22,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-4 c 0,-0.554 0.446,-1 1,-1 z"
+       id="rect4190"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#f5d169;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       d="m 4,6.0000102 c -1.66199,10e-6 -3,1.33797 -3,2.99991 L 1,41.00009 C 1,42.66203 2.33801,44 4,44 l 15,0 6,0 19,0 c 1.66199,0 3,-1.33797 3,-2.99991 l 0,-24.00017 c 0,-1.66194 -1.33801,-2.99998 -3,-2.99991 l -19,0 -2,-7.0000499 C 22.84781,6.4672901 22.554,5.9996702 22,5.9999802 l -2,0 -1,0 z"
+       id="path4221"
+       sodipodi:nodetypes="ssssccsssscssccs" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#f6d87e;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       d="m 4,7.0011102 c -1.10799,0 -2,0.89198 -2,1.9999298 L 2,41.00006 C 2,42.10802 2.89201,43 4,43 l 15,0 5,0 20,0 c 1.108,0 2,-0.89198 2,-1.99994 l 0,-23.99927 c 0,-1.10795 -0.89201,-2.00547 -2,-1.99994 l -20,0 -2,-6.9997698 c -0.15219,-0.53267 -0.44669,-1.0276401 -1,-0.99997 l -2,0 z"
+       id="path4183-7"
+       sodipodi:nodetypes="ssssccsssscsscs" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/ark.svg
+++ b/Lüv Dark/apps/64/ark.svg
@@ -1,0 +1,1 @@
+utilities-file-archiver.svg

--- a/Lüv Dark/apps/64/gwenview.svg
+++ b/Lüv Dark/apps/64/gwenview.svg
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="gwenview.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.913579e-6,-2.6666677,14.99984,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999999,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193693e-6,2.666668,-2.0000002,-4.214526e-6,142.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <linearGradient
+       y2="46"
+       x2="24"
+       y1="42"
+       x1="24"
+       gradientTransform="translate(9.999995,1073.5196)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4228"
+       xlink:href="#Shadow"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4402"
+       x1="14"
+       y1="1086.5197"
+       x2="22"
+       y2="1091.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5.74e-6,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4410"
+       x1="37"
+       y1="1101.5197"
+       x2="32"
+       y2="1092.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5.74e-6,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4418"
+       x1="41"
+       y1="1111.5197"
+       x2="40"
+       y2="1104.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(5.74e-6,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4314"
+       cx="32"
+       cy="1096.5197"
+       fx="32"
+       fy="1096.5197"
+       r="11"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90909091,0,0,0.90909091,48.909088,83.683246)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4184"
+       cx="30"
+       cy="1069.5194"
+       fx="30"
+       fy="1069.5194"
+       r="2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-38,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4250"
+       x1="19"
+       y1="1107.0197"
+       x2="22"
+       y2="1107.0197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1064.5198,-1067.5197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4252"
+       x1="42"
+       y1="1107.0197"
+       x2="45"
+       y2="1107.0197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1064.5198,-1067.5197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4254"
+       x1="42"
+       y1="1084.0197"
+       x2="45"
+       y2="1084.0197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1064.5198,-1067.5197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4256"
+       x1="19"
+       y1="1084.0197"
+       x2="22"
+       y2="1084.0197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1064.5198,-1067.5197)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="52.051583"
+     inkscape:cy="39.081434"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m -8.001953,1068.0195 a 0.50005,0.50005 0 0 0 -0.388672,0.1875 l -4,5 A 0.50005,0.50005 0 0 0 -12,1074.0195 l 7,0 1,0 a 0.50005,0.50005 0 0 0 0.390625,-0.8125 l -4,-5 a 0.50005,0.50005 0 0 0 -0.392578,-0.1875 z m 0.002,1.3008 2.958984,3.6992 -5.917968,0 L -8,1069.3203 Z"
+       id="path4178"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4249-5"
+       d="m 56.999991,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.0000045,1075.5196 c -0.5539702,0 -0.9999997,0.446 -0.9999997,1 l 0,37 c 0,0.554 0.4460295,1 0.9999997,1 l 47.9999915,0 c 0.55397,0 1,-0.446 1,-1 l 0,-37 c 0,-0.554 -0.44603,-1 -1,-1 z"
+       id="rect4649"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       id="path4251-7"
+       d="m 6.9999998,1115.5196 0,4 49.9999912,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 4,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 0.9999998,0 0,-4 -2.9999998,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4160"
+       width="56"
+       height="44.999947"
+       x="4.0000067"
+       y="1072.5197"
+       ry="2.9999466" />
+    <rect
+       style="opacity:1;fill:#455a64;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4162"
+       width="54"
+       height="42.999947"
+       x="5.0000067"
+       y="1073.5197"
+       ry="1.9999467" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4164"
+       width="50"
+       height="38.999947"
+       x="7.0000067"
+       y="1075.5197"
+       ry="0.99994665" />
+    <path
+       style="opacity:1;fill:#ab47bc;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.0000045,1076.5196 0,37 47.9999915,0 0,-37 -47.9999915,0 z"
+       id="rect4273"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ec407a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 8.0000045,1076.5196 0,33.918 22.0000005,-33.918 -22.0000005,0 z"
+       id="path4396"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4402);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.000005,1076.5196 -22.0000005,33.918 0,3.082 23.9999995,-37 -1.999999,0 z"
+       id="path4400"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#7e57c2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 55.999996,1081.5958 -47.9999915,25.8457 0,6.0781 47.9999915,0 0,-31.9238 z"
+       id="path4406"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4410);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 55.999996,1079.5958 -47.9999915,25.8457 0,2 47.9999915,-25.8457 0,-2 z"
+       id="path4408"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#5c6bc0;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 55.999996,1103.7891 -47.9999915,6.461 0,3.2695 47.9999915,0 0,-9.7305 z"
+       id="path4414"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4418);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 55.999996,1101.7891 -47.9999915,6.461 0,2 47.9999915,-6.461 0,-2 z"
+       id="path4416"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#00ffff;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 93.999996,1103.5196 c -0.55397,0 -1,0.446 -1,1 l 0,1 -1,0 0,-1 -1,0 -1,0 0,1 -1,0 c -0.55397,0 -1,0.446 -1,1 l 0,6 c 0,0.554 0.44603,1 1,1 l 10,0 c 0.55397,0 1,-0.446 1,-1 l 0,-7 c 0,-0.554 -0.44603,-1 -1,-1 0,-0.554 -0.44603,-1 -1,-1 l -3,0 -1,0 z m 0,1 1,0 3,0 0,1 -4,0 0,-1 z m -4,2 1,0 2,0 6,0 0,5 0,1 -1,0 -8,0 0,-6 z m 4,1 a 2,2 0 0 0 -2,2 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 2,2 0 0 0 -2,-2 z m 3.5,0 a 0.5,0.5 0 0 0 -0.5,0.5 0.5,0.5 0 0 0 0.5,0.5 0.5,0.5 0 0 0 0.5,-0.5 0.5,0.5 0 0 0 -0.5,-0.5 z m -3.5,1 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z"
+       id="rect4456"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000080;fill-opacity:1"
+       d="m 93.9707,1073.5196 0.97071,2 -2.94141,0 -1.99219,0 a 5,5 0 0 1 3.96289,-2 z m 1.08789,0.1152 a 5,5 0 0 1 2.85352,1.7735 l -0.9707,1.9961 -0.44141,-0.8848 -0.5,-1 -0.94141,-1.8848 z m 3.48047,2.8047 a 5,5 0 0 1 0.46094,2.0801 5,5 0 0 1 -0.41992,2 l -2.08008,0 1,-2 1.03906,-2.0801 z m -7.03906,0.08 -1,2 -1.03906,2.0801 a 5,5 0 0 1 -0.46094,-2.08 5,5 0 0 1 0.41992,-2 l 2.08008,0 z m -0.44141,3.1152 0.94141,1.8848 0.94336,1.8848 a 5,5 0 0 1 -2.85352,-1.7754 l 0.96875,-1.9942 z m 6.9336,1.8848 a 5,5 0 0 1 -3.96485,2 l -0.9707,-2 2.94336,0 1.99219,0 z"
+       id="circle4518"
+       inkscape:connector-curvature="0" />
+    <circle
+       style="fill:url(#radialGradient4314);fill-opacity:1"
+       id="path4306"
+       cx="78.000015"
+       cy="1080.5195"
+       r="10" />
+    <circle
+       cy="1079.5194"
+       cx="78.000015"
+       id="circle4316"
+       style="fill:#4db6ac;fill-opacity:1"
+       r="9" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 74.000012,1074.5189 c -0.55397,0 -1,0.446 -1,1 l 0,8 c 0,0.554 0.44603,1 1,1 l 8,0 c 0.55397,0 1,-0.446 1,-1 l 0,-3 0,-5 c 0,-0.554 -0.44603,-1 -1,-1 l -8,0 z m 0,1 8,0 0,4 -1,-1 -3,3 -1,-1 -3,3 0,-8 z m 2.5,1 a 1.5,1.5 0 0 0 -1.5,1.5 1.5,1.5 0 0 0 1.5,1.5 1.5,1.5 0 0 0 1.5,-1.5 1.5,1.5 0 0 0 -1.5,-1.5 z"
+       id="path4618"
+       inkscape:connector-curvature="0" />
+    <circle
+       r="2"
+       cy="1069.5194"
+       cx="-8"
+       id="circle4180"
+       style="opacity:1;fill:url(#radialGradient4184);fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#78909c;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4174"
+       cx="-8"
+       cy="1068.5197"
+       r="2" />
+    <circle
+       r="1"
+       cy="1068.5197"
+       cx="-8"
+       id="circle4176"
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:0.46067421;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -52,1076.5196 0,37 48,0 0,-37 -48,0 z m 13,8 22,0 0,22 -22,0 0,-22 z"
+       id="rect4188"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -40,1083.5196 0,24 24,0 0,-24 -24,0 z m 1,1 22,0 0,22 -22,0 0,-22 z"
+       id="rect4190"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="38"
+       x="1083.5195"
+       height="3"
+       width="3"
+       id="rect4230"
+       style="opacity:1;fill:url(#linearGradient4250);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:1;fill:#4db6ac;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4199"
+       width="3"
+       height="3"
+       x="-41"
+       y="1082.5197" />
+    <rect
+       y="38"
+       x="1106.5195"
+       height="3"
+       width="3"
+       id="rect4234"
+       style="opacity:1;fill:url(#linearGradient4252);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:1;fill:#4db6ac;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4199-0"
+       width="3"
+       height="3"
+       x="-41"
+       y="1105.5197" />
+    <rect
+       y="15"
+       x="1083.5195"
+       height="3"
+       width="3"
+       id="rect4228"
+       style="opacity:1;fill:url(#linearGradient4256);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:1;fill:#4db6ac;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4199-9"
+       width="3"
+       height="3"
+       x="-18"
+       y="1082.5197" />
+    <rect
+       y="15"
+       x="1106.5195"
+       height="3"
+       width="3"
+       id="rect4232"
+       style="opacity:1;fill:url(#linearGradient4254);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:1;fill:#4db6ac;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4199-2"
+       width="3"
+       height="3"
+       x="-18"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4258"
+       width="1"
+       height="1"
+       x="-40"
+       y="1083.5197" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4258-5"
+       width="1"
+       height="1"
+       x="-40"
+       y="1106.5197" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4258-0"
+       width="1"
+       height="1"
+       x="-17"
+       y="1106.5197" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4258-8"
+       width="1"
+       height="1"
+       x="-17"
+       y="1083.5197" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/kate.svg
+++ b/Lüv Dark/apps/64/kate.svg
@@ -1,0 +1,1 @@
+utilities-text-editor.svg

--- a/Lüv Dark/apps/64/klipper.svg
+++ b/Lüv Dark/apps/64/klipper.svg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="klipper.svg"
+   inkscape:export-filename="/home/uri/kate-flattr.png"
+   inkscape:export-xdpi="360"
+   inkscape:export-ydpi="360">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,22.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,134.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4250"
+       x1="33"
+       y1="1070.5197"
+       x2="33"
+       y2="1074.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-3.3555e-4)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="18.826718"
+     inkscape:cx="42.457258"
+     inkscape:cy="27.374147"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 48.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 15,1115.5196 0,4 34,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 11.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#e5a861;fill-opacity:1"
+       id="rect3360"
+       width="40"
+       height="49.000053"
+       x="12"
+       y="1068.5197"
+       ry="2.9999466" />
+    <rect
+       style="opacity:1;fill:#e9b578;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4229"
+       width="38"
+       height="46.999947"
+       x="13"
+       y="1069.5197"
+       ry="1.9999467" />
+    <rect
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4231"
+       width="34"
+       height="43.000053"
+       x="15"
+       y="1071.5197"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4263"
+       width="32"
+       height="40.999947"
+       x="16"
+       y="1072.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#29b6f6;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4172"
+       width="34"
+       height="12.000053"
+       x="15"
+       y="1087.5197"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4250);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4248"
+       width="12"
+       height="3.0000534"
+       x="27"
+       y="1071.5198"
+       ry="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#9e9e9e;fill-opacity:1;stroke:none"
+       d="m 33,1064.5196 c -1.104543,0 -1.999962,0.8954 -2,2 l -4,2 0,5 12,0 0,-5 -4,-2 c -3.8e-5,-1.1046 -0.895457,-2 -2,-2 z m 0,1 c 0.552285,0 1,0.4477 1,1 0,0.5523 -0.447715,1 -1,1 -0.552285,0 -1,-0.4477 -1,-1 0,-0.5523 0.447715,-1 1,-1 z"
+       id="rect4149-2"
+       sodipodi:nodetypes="sccccccssssss" />
+    <rect
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4262"
+       width="16"
+       height="1"
+       x="30"
+       y="1077.5197" />
+    <rect
+       y="1079.5197"
+       x="30"
+       height="1"
+       width="16"
+       id="rect4264"
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4266"
+       width="4"
+       height="1"
+       x="30"
+       y="1084.5197" />
+    <rect
+       style="opacity:1;fill:#b3e5fc;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4174"
+       width="32"
+       height="10.000053"
+       x="16"
+       y="1088.5197"
+       ry="0" />
+    <path
+       id="path4270"
+       d="m 19,1089.5196 c -0.553971,0 -1,0.446 -1,1 l 0,6 c 0,0.554 0.446029,1 1,1 l 6,0 c 0.553971,0 1,-0.446 1,-1 l 0,-6 c 0,-0.554 -0.446029,-1 -1,-1 l -6,0 z m 1,2 4,0 0,4 -4,0 0,-4 z"
+       style="opacity:1;fill:#29b6f6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="1089.5197"
+       x="30"
+       height="1"
+       width="16"
+       id="rect4270"
+       style="opacity:1;fill:#546e7a;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#546e7a;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4272"
+       width="16"
+       height="1"
+       x="30"
+       y="1091.5197" />
+    <rect
+       y="1096.5197"
+       x="30"
+       height="1"
+       width="4"
+       id="rect4274"
+       style="opacity:1;fill:#546e7a;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19,1101.5196 c -0.553971,0 -1,0.446 -1,1 l 0,6 c 0,0.554 0.446029,1 1,1 l 6,0 c 0.553971,0 1,-0.446 1,-1 l 0,-6 c 0,-0.554 -0.446029,-1 -1,-1 l -6,0 z m 1,2 4,0 0,4 -4,0 0,-4 z"
+       id="path4272" />
+    <rect
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4278"
+       width="16"
+       height="1"
+       x="30"
+       y="1101.5197" />
+    <rect
+       y="1103.5197"
+       x="30"
+       height="1"
+       width="16"
+       id="rect4280"
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="rect4282"
+       width="4"
+       height="1"
+       x="30"
+       y="1108.5197" />
+    <path
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31,9.3 -3,1.7 0,3 10,0 0,-3 -3,-1.7 z"
+       transform="translate(0,1058.5196)"
+       id="rect4252"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 33 5 A 3 3 0 0 0 30 8 A 3 3 0 0 0 33 11 A 3 3 0 0 0 36 8 A 3 3 0 0 0 33 5 z M 33 6 A 2 2 0 0 1 35 8 A 2 2 0 0 1 33 10 A 2 2 0 0 1 31 8 A 2 2 0 0 1 33 6 z "
+       transform="translate(0,1058.5196)"
+       id="path4257" />
+    <path
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 19 19 C 18.446029 19 18 19.446029 18 20 L 18 26 C 18 26.553971 18.446029 27 19 27 L 25 27 C 25.553971 27 26 26.553971 26 26 L 26 20 C 26 19.446029 25.553971 19 25 19 L 19 19 z M 20 21 L 24 21 L 24 25 L 20 25 L 20 21 z "
+       transform="translate(0,1058.5196)"
+       id="rect4265" />
+    <rect
+       style="opacity:1;fill:#e1f5fe;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4176"
+       width="6"
+       height="6"
+       x="19"
+       y="1090.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#29b6f6;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4178"
+       width="4"
+       height="4"
+       x="20"
+       y="1091.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4180"
+       width="6"
+       height="6"
+       x="19"
+       y="1078.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4180-0"
+       width="6"
+       height="6"
+       x="19"
+       y="1102.5197"
+       ry="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/konqueror.svg
+++ b/Lüv Dark/apps/64/konqueror.svg
@@ -1,0 +1,394 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="konqueror.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="Shadow"
+       inkscape:collect="always">
+      <stop
+         id="stop4260"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30947712"
+         offset="0.30769235"
+         id="stop4262" />
+      <stop
+         id="stop4282"
+         offset="0.53846157"
+         style="stop-color:#000000;stop-opacity:0.09444445" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.13333334"
+         offset="0.69230771"
+         id="stop4284" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.11764706"
+         offset="0.8461538"
+         id="stop4264" />
+      <stop
+         id="stop4266"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <style
+       type="text/css"
+       id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      .ColorScheme-Background {
+        color:#eff0f1;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      .ColorScheme-ViewText {
+        color:#31363b;
+      }
+      .ColorScheme-ViewBackground {
+        color:#fcfcfc;
+      }
+      .ColorScheme-ViewHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ViewFocus{
+        color:#3daee9;
+      }
+      .ColorScheme-ButtonText {
+        color:#31363b;
+      }
+      .ColorScheme-ButtonBackground {
+        color:#eff0f1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#3daee9;
+      }
+      </style>
+    <style
+       id="current-color-scheme-1"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      .ColorScheme-Background {
+        color:#eff0f1;
+      }
+      .ColorScheme-Highlight {
+        color:#3daee9;
+      }
+      .ColorScheme-ViewText {
+        color:#31363b;
+      }
+      .ColorScheme-ViewBackground {
+        color:#fcfcfc;
+      }
+      .ColorScheme-ViewHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ViewFocus{
+        color:#3daee9;
+      }
+      .ColorScheme-ButtonText {
+        color:#31363b;
+      }
+      .ColorScheme-ButtonBackground {
+        color:#eff0f1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#93cee9;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#3daee9;
+      }
+      </style>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4256"
+       cx="18.800955"
+       cy="50.229359"
+       fx="18.800955"
+       fy="50.229359"
+       r="7.2236328"
+       gradientTransform="matrix(-1.7996488,1.0110349e-6,-1.0173123e-6,-1.9380835,63.835168,144.34866)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4270"
+       cx="22.0987"
+       cy="49.349384"
+       fx="22.0987"
+       fy="49.349384"
+       r="11.960859"
+       gradientTransform="matrix(-0.83606038,-1.0158102e-8,1.3983774e-8,-1.0032726,36.475847,88.510882)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4292"
+       x1="19"
+       y1="20"
+       x2="10"
+       y2="31.999937"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7996488,1.0110349e-6,1.0173123e-6,-1.9380835,0.243115,1202.8683)"
+       cx="18.800955"
+       cy="50.229359"
+       fx="18.800955"
+       fy="50.229359"
+       r="7.2236328" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4302"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83606038,-1.0158102e-8,-1.3983774e-8,-1.0032726,27.602436,1147.0305)"
+       cx="22.0987"
+       cy="49.349384"
+       fx="22.0987"
+       fy="49.349384"
+       r="11.960859" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4304"
+       gradientUnits="userSpaceOnUse"
+       x1="19"
+       y1="20"
+       x2="10"
+       y2="31.999937"
+       gradientTransform="matrix(-1,0,0,1,64.078283,1058.5196)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.3125"
+     inkscape:cx="19.906103"
+     inkscape:cy="32"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+    <sodipodi:guide
+       position="31.999998,32.000064"
+       orientation="26.999998,0"
+       id="guide4748" />
+    <sodipodi:guide
+       position="4.9999962,32.000064"
+       orientation="0,27.000002"
+       id="guide4754" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4294"
+       d="m 32.078283,1093.5196 14.447266,15.6504 -0.5,-0.029 c -2.14723,1.9241 -4.667668,3.3854 -7.404297,4.293 l -1.542969,3.0859 c 0,1.662 -1.33803,3 -3,3 l -2,0 0,-26 z"
+       style="fill:url(#radialGradient4300);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4296"
+       d="m 53.078283,1093.5196 c -0.01047,1.4455 -0.170178,2.8861 -0.476562,4.2988 l 1.894531,2.8711 c 1.439307,0.831 1.930594,2.6584 1.099609,4.0977 l -2,3.4648 c -0.830985,1.4393 -2.6603,1.9287 -4.099609,1.0977 l -2.970703,-0.1797 -14.447266,-15.6504 21,0 z"
+       style="fill:url(#radialGradient4302);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4298"
+       d="m 34.078283,1067.5196 c 1.66197,0 3,1.338 3,3 l 1.554688,3.1094 c 2.72914,0.9025 5.243944,2.3556 7.388671,4.2695 l 3.47461,-0.209 c 1.439309,-0.831 3.268624,-0.3416 4.099609,1.0977 l 2,3.4648 c 0.830985,1.4393 0.339698,3.2667 -1.099609,4.0977 l -1.91211,2.8965 c 0.310567,1.4038 0.47615,2.8358 0.494141,4.2734 l -21,0 0,-26 2,0 z"
+       style="fill:url(#linearGradient4304);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#radialGradient4256);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 32 35 L 17.552734 50.650391 L 18.052734 50.621094 C 20.199964 52.545194 22.720402 54.006462 25.457031 54.914062 L 27 58 C 27 59.662 28.33803 61 30 61 L 32 61 L 32 35 z "
+       id="path4252"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="fill:url(#radialGradient4270);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11 35 C 11.01047 36.4455 11.170178 37.886128 11.476562 39.298828 L 9.5820312 42.169922 C 8.1427234 43.000922 7.6514369 44.828278 8.4824219 46.267578 L 10.482422 49.732422 C 11.313407 51.171722 13.142722 51.661078 14.582031 50.830078 L 17.552734 50.650391 L 32 35 L 11 35 z "
+       id="path4247"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="fill:url(#linearGradient4292);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 30 9 C 28.33803 9 27 10.338 27 12 L 25.445312 15.109375 C 22.716172 16.011875 20.201368 17.465006 18.056641 19.378906 L 14.582031 19.169922 C 13.142722 18.338922 11.313407 18.828278 10.482422 20.267578 L 8.4824219 23.732422 C 7.6514369 25.171722 8.1427234 26.999078 9.5820312 27.830078 L 11.494141 30.726562 C 11.183574 32.130364 11.017991 33.5624 11 35 L 32 35 L 32 9 L 30 9 z "
+       id="path4240"
+       transform="translate(0,1058.5196)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4905"
+       d="m 14.581392,1075.6895 4.464144,0.2679 -6.50006,11.2584 -0.499978,0.866 -2.4640588,-3.7321 z"
+       style="fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 54.418561,1098.6895 -2.464059,-3.7321 -6.50006,11.2584 -0.499978,0.866 4.464143,0.2679 z"
+       id="path4907"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9.5814157,1098.6895 2.4641013,-3.7321 6.5,11.2584 0.5,0.866 -4.464101,0.2679 z"
+       id="path4901"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4903"
+       d="m 49.418584,1075.6895 -4.464101,0.2679 6.5,11.2584 0.5,0.866 2.464101,-3.7321 z"
+       style="fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4899"
+       d="m 27,1114.5196 -2,-4 13,0 1,0 -2,4 z"
+       style="fill:#607d8b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#607d8b;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="m 27,1068.5196 -2,4 13,0 1,0 -2,-4 z"
+       id="path4897"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#cfd8dc;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 30,8 c -1.108,0 -2,0.892 -2,2 l 0,3.425781 a 20,20 0 0 0 -10.953125,6.320313 l -2.964844,-1.710938 c -0.959556,-0.554 -2.178422,-0.227134 -2.732422,0.732422 l -2,3.464844 c -0.554,0.959556 -0.227134,2.178422 0.732422,2.732422 l 2.960938,1.710937 A 20,20 0 0 0 12,33 a 20,20 0 0 0 1.050781,6.320312 l -2.96875,1.714844 c -0.959555,0.554 -1.286422,1.772866 -0.732422,2.732422 l 2,3.464844 c 0.554,0.959556 1.772866,1.286422 2.732422,0.732422 L 17.052734,46.25 A 20,20 0 0 0 28,52.59375 L 28,56 c 0,1.108 0.892,2 2,2 l 4,0 c 1.108,0 2,-0.892 2,-2 l 0,-3.425781 a 20,20 0 0 0 10.95313,-6.320313 l 2.96484,1.710938 c 0.95956,0.554 2.17842,0.227134 2.73242,-0.732422 l 2,-3.464844 c 0.554,-0.959556 0.22714,-2.178422 -0.73242,-2.732422 L 50.95703,39.324219 A 20,20 0 0 0 52,33 20,20 0 0 0 50.94922,26.679688 l 2.96875,-1.714844 c 0.95956,-0.554 1.28642,-1.772866 0.73242,-2.732422 l -2,-3.464844 c -0.554,-0.959556 -1.77286,-1.286422 -2.73242,-0.732422 L 46.94727,19.75 A 20,20 0 0 0 36,13.40625 L 36,10 C 36,8.892 35.108,8 34,8 l -4,0 z"
+       id="rect4817"
+       inkscape:connector-curvature="0"
+       transform="translate(0,1058.5196)" />
+    <circle
+       style="opacity:1;fill:#607d8b;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4151"
+       cx="32"
+       cy="1091.5194"
+       r="17" />
+    <circle
+       r="16"
+       cy="1091.5194"
+       cx="32"
+       id="circle4153"
+       style="opacity:1;fill:#64b5f6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#bbdefb;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 26.689453,18.978516 C 20.860126,21.185235 17.002905,26.76697 17,33 c 0,8.284271 6.715729,15 15,15 3.243325,-0.0049 6.397686,-1.060951 8.990234,-3.009766 L 37,45 c 0,0 0,-5 -1,-5 -1,0 -2,-1 -2,0 0,1 -2,3 -2,3 l -1,0 -5,-4 -1,-1 -2,0 1,-4 5,-1 c 0,0 1,-1 2,-1 l 3,0 3,0 1,-1 0,-3 1,-2 -6,-6 z"
+       transform="translate(0,1058.5196)"
+       id="path4160"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccsscccccccsccccccc" />
+    <path
+       style="opacity:1;fill:#607d8b;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 30,7 c -1.66197,0 -3,1.3380296 -3,3 l 0,2.640625 a 20.999977,21.000063 0 0 0 -10.119141,5.857422 l -2.298828,-1.328125 c -1.439309,-0.830985 -3.268624,-0.341652 -4.099609,1.097656 l -2,3.464844 c -0.830985,1.439308 -0.339699,3.266671 1.099609,4.097656 l 2.296875,1.326172 A 20.999977,21.000063 0 0 0 11,33 20.999977,21.000063 0 0 0 11.867188,38.849609 L 9.582031,40.169922 C 8.142723,41.000907 7.651437,42.82827 8.482422,44.267578 l 2,3.464844 c 0.830985,1.439308 2.6603,1.928641 4.099609,1.097656 l 2.291016,-1.322266 A 20.999977,21.000063 0 0 0 27,53.371094 L 27,56 c 0,1.66197 1.33803,3 3,3 l 4,0 c 1.66197,0 3,-1.33803 3,-3 l 0,-2.640625 a 20.999977,21.000063 0 0 0 10.11914,-5.857422 l 2.29883,1.328125 c 1.43931,0.830985 3.26862,0.341652 4.09961,-1.097656 l 2,-3.464844 c 0.83098,-1.439308 0.3397,-3.266671 -1.09961,-4.097656 L 52.12109,38.84375 A 20.999977,21.000063 0 0 0 53,33 20.999977,21.000063 0 0 0 52.13281,27.150391 l 2.28516,-1.320313 c 1.43931,-0.830985 1.93059,-2.658348 1.09961,-4.097656 l -2,-3.464844 c -0.83099,-1.439308 -2.6603,-1.928641 -4.09961,-1.097656 l -2.29102,1.322266 A 20.999977,21.000063 0 0 0 37,12.628906 L 37,10 C 37,8.3380296 35.66197,7 34,7 l -4,0 z m 0,1 4,0 c 1.108,0 2,0.892 2,2 L 36,12.402344 36,13 36,13.40625 A 19.999981,20.000063 0 0 1 46.94727,19.75 l 0.37304,-0.214844 0.1836,-0.105468 0.33789,-0.195313 2.07617,-1.199219 c 0.95956,-0.554 2.17842,-0.227134 2.73242,0.732422 l 2,3.464844 c 0.554,0.959556 0.22714,2.178422 -0.73242,2.732422 l -2.08399,1.203125 -0.27929,0.162109 -0.23438,0.134766 -0.37109,0.214844 A 19.999981,20.000063 0 0 1 52,33 19.999981,20.000063 0 0 1 50.95703,39.324219 l 0.36328,0.210937 0.51172,0.294922 2.08594,1.205078 c 0.95956,0.554 1.28642,1.772866 0.73242,2.732422 l -2,3.464844 c -0.554,0.959556 -1.77286,1.286422 -2.73242,0.732422 L 47.83008,46.759766 47.32031,46.464844 46.95313,46.253906 A 19.999981,20.000063 0 0 1 36,52.574219 L 36,53 36,53.607422 36,56 c 0,1.108 -0.892,2 -2,2 l -4,0 c -1.108,0 -2,-0.892 -2,-2 L 28,53.597656 28,53 28,52.59375 A 19.999981,20.000063 0 0 1 17.052734,46.25 l -0.373046,0.214844 -0.183594,0.105468 -0.337891,0.195313 -2.076172,1.199219 c -0.959556,0.554 -2.178422,0.227134 -2.732422,-0.732422 l -2,-3.464844 c -0.554,-0.959556 -0.227134,-2.178422 0.732422,-2.732422 l 2.083985,-1.203125 0.279296,-0.162109 0.234376,-0.134766 0.371093,-0.214844 A 19.999981,20.000063 0 0 1 12,33 19.999981,20.000063 0 0 1 13.042969,26.675781 l -0.363281,-0.210937 -0.511719,-0.294922 -2.085938,-1.205078 c -0.959556,-0.554 -1.286422,-1.772866 -0.732422,-2.732422 l 2,-3.464844 c 0.554,-0.959556 1.772866,-1.286422 2.732422,-0.732422 l 2.087891,1.205078 0.509766,0.294922 0.367187,0.210938 A 19.999981,20.000063 0 0 1 28,13.425781 L 28,13 28,12.392578 28,10 c 0,-1.108 0.892,-2 2,-2 z"
+       id="rect4154"
+       inkscape:connector-curvature="0"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="fill:#cfd8dc;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       d="M 28 10 L 26 14 L 32 14 L 38 14 L 36 10 L 32 10 L 28 10 z "
+       transform="translate(0,1058.5196)"
+       id="path4909" />
+    <path
+       id="path4914"
+       d="m 28,1114.5196 -2,-4 6,0 6,0 -2,4 -4,0 -4,0 z"
+       style="fill:#cfd8dc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4916"
+       d="m 49.918584,1076.5555 -4.464101,0.2679 3,5.1962 3,5.1962 2.464101,-3.7321 -2,-3.4641 -2,-3.4641 z"
+       style="fill:#cfd8dc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#cfd8dc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.081416,1099.5555 2.464101,-3.7321 3,5.1962 3,5.1962 -4.464101,0.2679 -2,-3.4641 -2,-3.4641 z"
+       id="path4918" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#cfd8dc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 49.918584,1106.4837 -4.464101,-0.2679 3,-5.1962 3,-5.1962 2.464101,3.7321 -2,3.4641 -2,3.4641 z"
+       id="path4920" />
+    <path
+       id="path4922"
+       d="m 10.081416,1083.4837 2.464101,3.7321 3,-5.1962 3,-5.1962 -4.464101,-0.2679 -2,3.4641 -2,3.4641 z"
+       style="fill:#cfd8dc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/kwalletmanager.svg
+++ b/Lüv Dark/apps/64/kwalletmanager.svg
@@ -1,0 +1,433 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kwalletmanager.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,14.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,142.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <style
+       id="current-color-scheme"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      </style>
+    <linearGradient
+       gradientTransform="translate(15,14.9999)"
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4222"
+       x1="39"
+       y1="1088.5197"
+       x2="36"
+       y2="1091.5197"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="translate(17,16.9999)"
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4236"
+       cx="28"
+       cy="1085.5197"
+       fx="28"
+       fy="1085.5197"
+       r="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(15,14.9999)"
+       x1="34"
+       y1="1088.5197"
+       x2="38"
+       y2="1092.5197" />
+    <radialGradient
+       gradientTransform="translate(17,14.9999)"
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4244"
+       cx="25.5"
+       cy="1092.0197"
+       fx="25.5"
+       fy="1092.0197"
+       r="1.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       gradientTransform="translate(17,12.9999)"
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4252"
+       cx="30"
+       cy="1098.5197"
+       fx="30"
+       fy="1098.5197"
+       r="2"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.681164"
+     inkscape:cx="44.227557"
+     inkscape:cy="15.190804"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,51.000002"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 56.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 7,1115.5196 0,4 50,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 3.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#26a69a;fill-opacity:1"
+       id="rect3360"
+       width="56"
+       height="43.999878"
+       x="4"
+       y="1073.5197"
+       ry="2.9999466" />
+    <rect
+       style="fill:#4db6ac;fill-opacity:1"
+       id="rect3362"
+       width="54"
+       height="41.999947"
+       x="5"
+       y="-1116.5197"
+       ry="1.9999467"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4163"
+       width="56"
+       height="6.0000534"
+       x="4"
+       y="1079.5198"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4167"
+       width="1"
+       height="6"
+       x="4"
+       y="1079.5198" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4167-9"
+       width="1"
+       height="6"
+       x="59"
+       y="1079.5198" />
+    <rect
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4184"
+       width="35"
+       height="7"
+       x="9"
+       y="1088.5199"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4186"
+       width="33"
+       height="5"
+       x="10"
+       y="1089.5199"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4188"
+       width="7"
+       height="5.0002975"
+       x="46"
+       y="1089.5197"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4190"
+       width="5"
+       height="3.0002975"
+       x="47"
+       y="1090.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4192"
+       width="3"
+       height="1.0002974"
+       x="48"
+       y="1091.5197"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4196"
+       width="9"
+       height="1"
+       x="11"
+       y="1090.5199" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4198"
+       width="17"
+       height="1"
+       x="11"
+       y="1092.5199" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4230"
+       width="5"
+       height="0.99994665"
+       x="9"
+       y="1099.5197" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4232"
+       width="17"
+       height="1.0000688"
+       x="15"
+       y="1099.5197" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4240"
+       width="3"
+       height="1"
+       x="9"
+       y="1101.5197" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4244"
+       width="8"
+       height="1"
+       x="13"
+       y="1101.5197" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4252"
+       width="2"
+       height="1"
+       x="9"
+       y="1103.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4254"
+       width="4"
+       height="1"
+       x="12"
+       y="1103.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4256"
+       width="7"
+       height="1"
+       x="17"
+       y="1103.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4258"
+       width="10"
+       height="1"
+       x="21.999996"
+       y="1101.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4264"
+       width="5"
+       height="1"
+       x="9"
+       y="1105.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4266"
+       width="6.0000019"
+       height="0.99994665"
+       x="14.999998"
+       y="1105.5198" />
+    <rect
+       style="opacity:1;fill:#00796b;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4268"
+       width="10"
+       height="1"
+       x="21.999998"
+       y="1105.5198" />
+    <rect
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4270"
+       width="10"
+       height="1"
+       x="9"
+       y="1109.5198" />
+    <rect
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4272"
+       width="4"
+       height="1"
+       x="9"
+       y="1111.5198" />
+    <path
+       id="path4224"
+       d="m 45,1101.5196 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z"
+       style="color:#4d4d4d;fill:url(#radialGradient4236);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4226"
+       d="m 42.5,1105.5196 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 z"
+       style="color:#4d4d4d;fill:url(#radialGradient4244);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4228"
+       d="m 47,1109.5196 c -1.108,0 -2,0.892 -2,2 0,1.108 0.892,2 2,2 1.108,0 2,-0.892 2,-2 0,-1.108 -0.892,-2 -2,-2 z"
+       style="color:#4d4d4d;fill:url(#radialGradient4252);fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#4d4d4d;fill:url(#linearGradient4269);fill-opacity:1;stroke:none"
+       d="m 53,1102.5195 -2,2 -3,3 2,2 3,-3 2,-2 -2,-2 z"
+       id="path4267" />
+    <path
+       style="color:#4d4d4d;fill:#eeeeee;fill-opacity:1;stroke:none"
+       d="m 50,1098.5195 -2,2 3,3 -3,3 2,2 3,-3 2,-2 -5,-5 z m -5,2 c -0.554,0 -1,0.446 -1,1 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 0,-0.554 -0.446,-1 -1,-1 z m -2.5,4 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 0.831,0 1.5,-0.669 1.5,-1.5 0,-0.831 -0.669,-1.5 -1.5,-1.5 z m 4.5,4 c -1.108,0 -2,0.892 -2,2 0,1.108 0.892,2 2,2 1.108,0 2,-0.892 2,-2 0,-1.108 -0.892,-2 -2,-2 z"
+       id="path4354"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.3;fill:url(#linearGradient4222);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 51,1103.5195 2,2 -3,3 c 0,0 -2,-2 -2,-2 z"
+       id="path4220"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/okular.svg
+++ b/Lüv Dark/apps/64/okular.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="okular.svg"
+   inkscape:export-filename="/home/uri/kate-flattr.png"
+   inkscape:export-xdpi="360"
+   inkscape:export-ydpi="360">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,21.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,135.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4170"
+       x1="23"
+       y1="26"
+       x2="25"
+       y2="29"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4180"
+       gradientUnits="userSpaceOnUse"
+       x1="23"
+       y1="26"
+       x2="25"
+       y2="29"
+       gradientTransform="matrix(-1,0,0,1,52,1058.5196)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="32.483104"
+     inkscape:cy="37.322307"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 49.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 14,1115.5196 0,4 36,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 10.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#37474f;fill-opacity:1"
+       d="M 17 7 L 17 59 L 50 59 C 51.66197 59 53 57.66197 53 56 L 53 10 C 53 8.3380296 51.66197 7 50 7 L 17 7 z "
+       id="path4194"
+       transform="translate(0,1058.5196)" />
+    <rect
+       style="opacity:1;fill:#546e7a;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4237"
+       width="40"
+       height="50"
+       x="12"
+       y="1066.5197"
+       ry="1.9999467" />
+    <path
+       id="path4178"
+       d="m 26,1067.5196 4,0 1,0 0,1 0,20 a 1.0001,1.0001 0 0 1 -1.707031,0.707 L 26,1085.9337 l 0,-18.4141 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4180);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4170);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 26 9 L 22 9 L 21 9 L 21 10 L 21 30 A 1.0001 1.0001 0 0 0 22.707031 30.707031 L 26 27.414062 L 26 9 z "
+       id="path4168"
+       transform="translate(0,1058.5196)" />
+    <path
+       inkscape:connector-curvature="0"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:'Impregnable Personal Use Only';-inkscape-font-specification:'Impregnable Personal Use Only';letter-spacing:0px;word-spacing:0px;fill:#90a4ae;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 52.000469,1077.2266 c -1.096939,0.4532 -2.194079,1.0487 -3.291016,1.8281 -1.844633,1.3107 -3.59172,2.9609 -5.242187,4.9512 -1.60192,1.9417 -3.058481,4.1513 -4.369141,6.627 -1.26212,2.4271 -2.208783,4.9509 -2.839844,7.5722 -0.679599,2.6213 -0.970133,5.0246 -0.873046,7.209 0.145626,2.1359 0.606125,3.9324 1.382812,5.3887 0.776693,1.4563 1.843925,2.4998 3.203125,3.1308 1.359207,0.6311 2.962001,0.7517 4.806641,0.3633 1.796086,-0.3883 3.616297,-1.2362 5.460937,-2.5469 0.603814,-0.4335 1.187534,-0.9076 1.761719,-1.4004 l 0,-4.5703 c -0.362065,0.2822 -0.730533,0.5509 -1.105469,0.8008 -1.456293,0.9223 -2.865402,1.456 -4.224609,1.6016 -1.407747,0.1456 -2.595546,-0.098 -3.566406,-0.7285 -0.97086,-0.6311 -1.72384,-1.5778 -2.257813,-2.8399 -0.485433,-1.2621 -0.728515,-2.7661 -0.728515,-4.5137 -1e-6,-1.796 0.290526,-3.7388 0.873046,-5.8261 0.582514,-2.0874 1.408616,-4.0775 2.476563,-5.9707 1.067947,-1.9417 2.232021,-3.6414 3.494141,-5.0977 1.310666,-1.5048 2.670378,-2.7183 4.078124,-3.6406 0.321546,-0.2144 0.641759,-0.4001 0.960938,-0.5742 l 0,-1.7637 z"
+       id="path4542" />
+    <path
+       style="fill:#37474f;fill-opacity:1"
+       d="M 14 7 C 12.33803 7 11 8.3380296 11 10 L 11 56 C 11 57.66197 12.33803 59 14 59 L 17 59 L 17 58 L 16 58 L 16 8 L 17 8 L 17 7 L 14 7 z "
+       transform="translate(0,1058.5196)"
+       id="rect3360" />
+    <path
+       id="path4209-0"
+       d="m 21,1066.5199 0,1 0,20 a 1.0001,1.0001 0 0 0 1.707031,0.707 L 26,1084.934 l 3.292969,3.2929 A 1.0001,1.0001 0 0 0 31,1087.5199 l 0,-20 0,-1 -1,0 -8,0 -1,0 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#039be5;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4199-9"
+       d="m 22,1067.5199 0,20 1,-1 0,-0.014 2.292969,-2.2929 c 0.39053,-0.3904 1.023532,-0.3904 1.414062,0 L 29,1086.5062 l 0,0.014 1,1 0,-20 -1,0 -6,0 -1,0 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#03a9f4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4161"
+       width="1"
+       height="50"
+       x="16"
+       y="1066.5197" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/preferences-system.svg
+++ b/Lüv Dark/apps/64/preferences-system.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="preferences-system.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,15.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,141.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4176"
+       cx="42"
+       cy="1090.5197"
+       fx="42"
+       fy="1090.5197"
+       r="7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4285713,0,0,1.4285713,-20,-465.36518)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.96875"
+     inkscape:cx="52.879485"
+     inkscape:cy="29.25957"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 55.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 8,1115.5196 0,4 48,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 4.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#37474f;fill-opacity:1"
+       id="rect3360"
+       width="54"
+       height="52.999931"
+       x="5"
+       y="1064.5197"
+       ry="2.9999466" />
+    <rect
+       style="fill:#455a64;fill-opacity:1"
+       id="rect3362"
+       width="52"
+       height="50.999947"
+       x="6"
+       y="1065.5197"
+       ry="1.9999467" />
+    <rect
+       style="fill:#4fc3f7;fill-opacity:1"
+       id="rect3364"
+       width="34"
+       height="12.000053"
+       x="15"
+       y="1085.5192"
+       ry="6.0000267" />
+    <rect
+       style="fill:#81d4fa;fill-opacity:1"
+       id="rect3366"
+       width="32"
+       height="10.000053"
+       x="16"
+       y="1086.5193"
+       ry="4.9863691" />
+    <circle
+       style="fill:url(#radialGradient4176);fill-opacity:1"
+       id="path3368"
+       cx="40"
+       cy="1092.5194"
+       r="10" />
+    <circle
+       r="9"
+       cy="1091.5194"
+       cx="40"
+       id="circle4178"
+       style="fill:#03a9f4;fill-opacity:1" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-file-manager.svg
+++ b/Lüv Dark/apps/64/system-file-manager.svg
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-file-manager.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,12.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,144.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="-9.2300797"
+     inkscape:cy="32.825565"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="963"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 58.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 4.999995,1115.5196 0,4 54,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 1.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#ebb10f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 6.999945,1071.5197 52.00009,0 c 1.66196,0 2.99995,1.3379 2.99995,2.9999 l 0,36 c 0,1.662 -1.33799,2.9999 -2.99995,2.9999 l -52.00009,0 c -1.66197,0 -2.99995,-1.3379 -2.99995,-2.9999 l 0,-36 c 0,-1.662 1.33798,-2.9999 2.99995,-2.9999 z"
+       id="rect4194-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="opacity:1;fill:#e8e5dc;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33.999985,1073.5196 24,0 c 1.108,0 2,0.892 2,2 l 0,3 c 0,1.108 -0.892,2 -2,2 l -24,0 c -1.108,0 -2,-0.892 -2,-2 l 0,-3 c 0,-1.108 0.892,-2 2,-2 z"
+       id="rect4207-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="opacity:1;fill:#fffbec;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.999985,1074.5196 25,0 c 0.55401,0 1,0.446 1,1 l 0,4 c 0,0.554 -0.44599,1 -1,1 l -25,0 c -0.55399,0 -1,-0.446 -1,-1 l 0,-4 c 0,-0.554 0.44601,-1 1,-1 z"
+       id="rect4209-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="opacity:1;fill:#f3c749;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.999995,1077.5196 0,40 27.00001,0 c 1.66197,0 3,-1.338 3,-3 l 0,-34 c 0,-1.662 -1.33803,-3 -3,-3 z"
+       id="path4220-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssssc" />
+    <path
+       style="opacity:1;fill:#f3c749;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.999995,1068.5196 c -1.66197,0 -3,1.338 -3,3 l 0,43 c 0,1.662 1.33803,3 3,3 l 27,0 0,-49 z"
+       id="path4213-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssssccs" />
+    <path
+       style="opacity:1;fill:#f6d87e;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.999995,1069.5196 -27,0 c -1.108,0 -2,0.892 -2,2 l 0,43 c 0,1.108 0.892,2 2,2 l 27,0 z"
+       id="path4223-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssscc" />
+    <path
+       style="opacity:1;fill:#f3c749;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.999995,1068.5196 18,0 c 0.554,0 0.86563,0.4625 1,1 l 2,8 c 0.13437,0.5375 -0.446,1 -1,1 l -20,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-8 c 0,-0.554 0.446,-1 1,-1 z"
+       id="path4225-1-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       style="opacity:1;fill:#f6d87e;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.999995,1078.5196 0,38 27.00001,0 c 1.108,0 2,-0.892 2,-2 l 0,-34 c 0,-1.108 -0.892,-2 -2,-2 z"
+       id="rect4211-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssssc" />
+    <path
+       sodipodi:nodetypes="sssssssss"
+       inkscape:connector-curvature="0"
+       id="path4227-7-4"
+       d="m 10.999995,1069.5196 20,0 c 0.554,0 0.86563,0.4625 1,1 l 2,8 c 0.13437,0.5375 -0.446,1 -1,1 l -22,0 c -0.554,0 -1,-0.446 -1,-1 l 0,-8 c 0,-0.554 0.446,-1 1,-1 z"
+       style="opacity:1;fill:#f6d87e;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-lock-screen.svg
+++ b/Lüv Dark/apps/64/system-lock-screen.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-lock-screen.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <linearGradient
+       gradientTransform="translate(0,1067.5196)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="linearGradient4202"
+       x1="33"
+       y1="34"
+       x2="33"
+       y2="37"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4192">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4194" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4196" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4206"
+       cx="20"
+       cy="36.5"
+       fx="20"
+       fy="36.5"
+       r="1"
+       gradientTransform="matrix(-2,0,0,-3,66,1211.0196)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4204"
+       cx="41.5"
+       cy="35.166672"
+       fx="41.5"
+       fy="35.166672"
+       r="1"
+       gradientTransform="matrix(1.7293317e-6,2.999998,-1.9999951,1.1528856e-6,108.3331,977.01964)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="28.864781"
+     inkscape:cy="30.112169"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#7e57c2;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#9575cd;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#ede7f6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       id="rect4170"
+       width="12"
+       height="18.999947"
+       x="26"
+       y="1080.5197"
+       ry="6" />
+    <rect
+       style="opacity:1;fill:#9575cd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       id="rect4172"
+       width="6"
+       height="14.999947"
+       x="29"
+       y="1083.5197"
+       ry="3" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#radialGradient4204);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38,1101.5196 0,3 1,0 c 0.55397,0 1,-0.446 1,-1 l 0,-2 -2,0 z"
+       id="path4184" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#radialGradient4206);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26,1101.5196 -2,0 0,2 c 0,0.554 0.44603,1 1,1 l 1,0 0,-3 z"
+       id="path4182" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26,1101.5196 0,3 12,0 0,-3 z"
+       id="rect4169"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="opacity:1;fill:#ede7f6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       id="rect4168"
+       width="16"
+       height="11.999947"
+       x="24"
+       y="1091.5197"
+       ry="0.99994701" />
+    <ellipse
+       style="opacity:1;fill:#9575cd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       id="path4174"
+       cx="31.999954"
+       cy="1096.52"
+       rx="1.9999567"
+       ry="2.0000002" />
+    <rect
+       style="opacity:1;fill:#9575cd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       id="rect4176"
+       width="2"
+       height="3.9999466"
+       x="31"
+       y="1096.5197"
+       ry="0.99994665" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-log-out.svg
+++ b/Lüv Dark/apps/64/system-log-out.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-log-out.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4434"
+       inkscape:collect="always">
+      <stop
+         id="stop4436"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.58725488" />
+      <stop
+         id="stop4438"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4223">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4225" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4227" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4211">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4213" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4215" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4201">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4203" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4205" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4201"
+       id="radialGradient4207"
+       cx="20.999998"
+       cy="1092.6863"
+       fx="20.999998"
+       fy="1092.6863"
+       r="1"
+       gradientTransform="matrix(-2,-1.522641e-6,1.5225279e-6,-1.9998514,62.998334,3278.73)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4211"
+       id="linearGradient4217"
+       x1="28"
+       y1="1093.5197"
+       x2="28"
+       y2="1095.5197"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4223"
+       id="linearGradient4229"
+       x1="38.374481"
+       y1="1093.6222"
+       x2="40.054394"
+       y2="1095.8732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1057.5196)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4434"
+       id="radialGradient4432"
+       cx="33.737705"
+       cy="41.510124"
+       fx="33.737705"
+       fy="41.510124"
+       r="0.50000268"
+       gradientTransform="matrix(-3.9999921,9.163951e-6,-8.7899131e-6,-3.9999707,169.95091,206.03898)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13"
+     inkscape:cx="32"
+     inkscape:cy="32"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="false"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+    <sodipodi:guide
+       position="17,15.999825"
+       orientation="-30,0"
+       id="guide4167" />
+    <sodipodi:guide
+       position="17,45.999827"
+       orientation="0,30"
+       id="guide4169" />
+    <sodipodi:guide
+       position="47,45.999827"
+       orientation="30,0"
+       id="guide4171" />
+    <sodipodi:guide
+       position="47,15.999825"
+       orientation="0,-30"
+       id="guide4173" />
+    <sodipodi:guide
+       position="25,37.000002"
+       orientation="1,0"
+       id="guide4214" />
+    <sodipodi:guide
+       position="39,39.000002"
+       orientation="1,0"
+       id="guide4216" />
+    <sodipodi:guide
+       position="39,38.000002"
+       orientation="0,1"
+       id="guide4218" />
+    <sodipodi:guide
+       position="39,24.000001"
+       orientation="0,1"
+       id="guide4220" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#ab47bc;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="-1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#ba68c8;fill-opacity:1;stroke:none;stroke-opacity:1"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4217);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4209"
+       width="13"
+       height="3"
+       x="21"
+       y="1092.5197" />
+    <rect
+       style="opacity:1;fill:url(#radialGradient4207);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4193"
+       width="2"
+       height="3.0000534"
+       x="19"
+       y="1092.5197"
+       ry="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4432);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 34 39 L 34 40.998047 L 34 41 C 34.003757 41.507259 34.387928 42.002141 35 42 L 35 41 L 35 39.738281 L 35 39 L 34 39 z "
+       transform="translate(0,1058.5196)"
+       id="path4430" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4229);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 44 33 A 0.99651976 0.99659913 0 0 0 43.382812 33.21875 L 35 39.738281 L 35 42 A 0.99651976 0.99659913 0 0 0 35.638672 41.765625 L 44.605469 34.791016 A 0.99651976 0.99659913 0 0 0 44 33 z "
+       id="path4219"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:#f3e5f5;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.960498,1083.5197 c -0.537005,0.021 -0.961296,0.4626 -0.960938,1 l 0,4 -14,0 c -0.55397,0 -1,0.446 -1,1 l 0,4 c 0,0.5539 0.44603,1 1,1 l 14,0 0,4 c 8.05e-4,0.8312 0.956494,1.2987 1.613281,0.789 l 9.001953,-7 c 0.514196,-0.4003 0.514196,-1.1777 0,-1.5781 l -9.001953,-7 c -0.185814,-0.1449 -0.416802,-0.2196 -0.652343,-0.2109 z"
+       id="rect4186"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-reboot.svg
+++ b/Lüv Dark/apps/64/system-reboot.svg
@@ -1,0 +1,461 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-reboot.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4291"
+       inkscape:collect="always">
+      <stop
+         id="stop4293"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.30980393" />
+      <stop
+         id="stop4297"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4319">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4321" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1"
+         id="stop4323" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4303"
+       inkscape:collect="always">
+      <stop
+         id="stop4305"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.49803922;"
+         offset="0.25"
+         id="stop4307" />
+      <stop
+         id="stop4309"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4285"
+       cx="32"
+       cy="1092.5197"
+       fx="32"
+       fy="1092.5197"
+       r="15"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(60,0)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4303"
+       id="radialGradient4301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9112776e-6,1.0666666,-1.0000032,1.7947916e-6,1180.523,1049.0223)"
+       cx="26.71435"
+       cy="1103.5195"
+       fx="26.71435"
+       fy="1103.5195"
+       r="15" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4319"
+       id="linearGradient4325"
+       x1="41.1875"
+       y1="1083.6447"
+       x2="40.75"
+       y2="1087.0509"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(60,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4289"
+       x1="749.47559"
+       y1="-781.78809"
+       x2="751.87115"
+       y2="-781.87115"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4299"
+       x1="1092.5197"
+       y1="-19"
+       x2="1094.5197"
+       y2="-19"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4301"
+       x1="795.06183"
+       y1="762.90076"
+       x2="797.15558"
+       y2="762.90073"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4304"
+       x1="32"
+       y1="1107.5197"
+       x2="32"
+       y2="1109.5197"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4314"
+       gradientUnits="userSpaceOnUse"
+       x1="32"
+       y1="1107.5197"
+       x2="32"
+       y2="1109.5197"
+       gradientTransform="translate(-63.999998,-26)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4316"
+       gradientUnits="userSpaceOnUse"
+       x1="1092.5197"
+       y1="-19"
+       x2="1094.5197"
+       y2="-19"
+       gradientTransform="translate(0,63.999998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4318"
+       gradientUnits="userSpaceOnUse"
+       x1="749.47559"
+       y1="-781.78809"
+       x2="751.87115"
+       y2="-781.87115"
+       gradientTransform="translate(45.254833,45.254833)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4291"
+       id="linearGradient4320"
+       gradientUnits="userSpaceOnUse"
+       x1="795.06183"
+       y1="762.90076"
+       x2="797.15558"
+       y2="762.90073"
+       gradientTransform="translate(-45.254833,45.254833)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="85.723414"
+     inkscape:cy="0.63423609"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:0.30980392;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 92 21 A 12 12 0 0 0 80 33 A 12 12 0 0 0 92 45 A 12 12 0 0 0 100.48047 41.480469 L 99.773438 40.773438 A 11 11 0 0 1 92 44 A 11 11 0 0 1 81 33 A 11 11 0 0 1 92 22 A 11 11 0 0 1 99.773438 25.226562 L 100.48047 24.519531 A 12 12 0 0 0 92 21 z "
+       transform="translate(0,1058.5196)"
+       id="path4324" />
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#26c6da;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="-1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#4dd0e1;fill-opacity:1;stroke:none;stroke-opacity:1"
+       transform="scale(1,-1)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4285);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-opacity:1"
+       d="m 80,1092.5196 -3,0 a 15,14.999825 0 0 0 15,15 15,14.999825 0 0 0 10.59961,-4.4004 l -0.082,-0.082 a 1.5,1.5 0 0 0 0.48242,-1.0977 1.5,1.5 0 0 0 -1.5,-1.5 1.5,1.5 0 0 0 -1.35937,0.8672 12,11.999859 0 0 1 -8.14063,3.2129 12,11.999859 0 0 1 -12,-12 z"
+       id="path4299"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4301);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4.0999999;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92,1077.5196 a 15,14.999825 0 0 0 -15,15 l 3,0 a 12,11.999859 0 0 1 0.06055,-1.1973 A 12,11.999859 0 0 1 92,1080.5196 a 12,11.999859 0 0 1 8.48047,3.5195 l 2.11914,-2.1191 A 15,14.999825 0 0 0 92,1077.5196 Z"
+       id="path4272"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4325);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 102.95084,1076.5208 c -0.24789,0.012 -0.48248,0.1157 -0.65817,0.291 l -6.999374,8.0012 c -0.594934,0.5966 -0.230817,1.6167 0.607388,1.7015 l 7.999096,1.0001 c 0.67738,0.068 1.22308,-0.5464 1.07612,-1.2112 l -0.99973,-9.0013 c -0.106,-0.4754 -0.53895,-0.8053 -1.02533,-0.7813 z"
+       id="path4317"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 92,1106.52 a 15,14.999912 0 0 1 -15,-15 15,14.999912 0 0 1 15,-15 15,14.999912 0 0 1 7.753906,2.1894 l 2.494144,-2.8477 c 0.57245,-0.6535 1.64863,-0.3163 1.74609,0.5469 l 1,8.9981 c 0.0674,0.6006 -0.40933,1.1233 -1.01367,1.1113 l 0,0 c -0.0353,0 -0.0705,2e-4 -0.10547,-0.01 l -8,-1 c -0.794301,-0.1008 -1.153978,-1.0477 -0.626953,-1.6504 L 97.75,1081.0004 A 12,12 0 0 0 92,1079.52 a 12,12 0 0 0 -12,12 12,12 0 0 0 12,12 12,12 0 0 0 8.48047,-3.5196 l 0.002,0 A 1.5,1.5 0 0 1 101.5,1099.6 a 1.5,1.5 0 0 1 1.5,1.5 1.5,1.5 0 0 1 -0.40039,1.0196 15,14.999912 0 0 1 -0.006,0.01 1.5,1.5 0 0 1 -0.17773,0.1602 A 15,14.999912 0 0 1 92,1106.52 Z m 0,-2 A 13,13 0 0 1 90.904297,1104.465 13,12.999847 0 0 0 92,1104.52 Z m 1.197266,-0.061 a 13,12.999847 0 0 0 0.65625,-0.09 13,13 0 0 1 -0.65625,0.09 z m -2.962891,-0.076 a 13,13 0 0 1 -0.630859,-0.096 13,12.999847 0 0 0 0.630859,0.096 z m 4.253906,-0.1113 a 13,12.999847 0 0 0 0.603516,-0.1445 13,13 0 0 1 -0.603516,0.1445 z m -5.52539,-0.1269 a 13,13 0 0 1 -0.611329,-0.1563 13,12.999847 0 0 0 0.611329,0.1563 z m 6.791015,-0.1856 a 13,12.999847 0 0 0 0.666016,-0.2344 13,13 0 0 1 -0.666016,0.2344 z m -8.039062,-0.1816 a 13,13 0 0 1 -0.597656,-0.2168 13,12.999847 0 0 0 0.597656,0.2168 z m 9.236328,-0.2461 a 13,12.999847 0 0 0 0.626953,-0.291 13,13 0 0 1 -0.626953,0.291 z m -10.429688,-0.2383 a 13,13 0 0 1 -0.585937,-0.2852 13,12.999847 0 0 0 0.585937,0.2852 z m 11.634766,-0.334 a 13,12.999847 0 0 0 0.490234,-0.291 13,13 0 0 1 -0.490234,0.291 z m -12.761719,-0.2598 a 13,13 0 0 1 -0.582031,-0.3574 13,12.999847 0 0 0 0.582031,0.3574 z m 13.869141,-0.4082 a 13,12.999847 0 0 0 0.490234,-0.3632 13,13 0 0 1 -0.490234,0.3632 z m -14.960938,-0.3144 a 13,13 0 0 1 -0.521484,-0.3945 13,12.999847 0 0 0 0.521484,0.3945 z m -1.023437,-0.836 a 13,13 0 0 1 -0.466797,-0.4335 13,12.999847 0 0 0 0.466797,0.4335 z m -0.900391,-0.9003 a 13,13 0 0 1 -0.441406,-0.502 13,12.999847 0 0 0 0.441406,0.502 z m -0.835937,-1.0235 a 13,13 0 0 1 -0.365235,-0.5097 13,12.999847 0 0 0 0.365235,0.5097 z m -0.722657,-1.0918 a 13,13 0 0 1 -0.308593,-0.541 13,12.999847 0 0 0 0.308593,0.541 z m -0.59375,-1.1269 a 13,13 0 0 1 -0.267578,-0.5957 13,12.999847 0 0 0 0.267578,0.5957 z m -0.482421,-1.1875 a 13,13 0 0 1 -0.214844,-0.6504 13,12.999847 0 0 0 0.214844,0.6504 z m -0.367188,-1.2442 a 13,13 0 0 1 -0.146484,-0.6504 13,12.999847 0 0 0 0.146484,0.6504 z m -0.240234,-1.2812 a 13,13 0 0 1 -0.08203,-0.6699 13,12.999847 0 0 0 0.08203,0.6699 z M 79,1091.52 a 13,13 0 0 1 0.05469,-1.0958 A 13,12.999847 0 0 0 79,1091.52 Z m 0.136719,-1.7657 a 13,13 0 0 1 0.0957,-0.6308 13,12.999847 0 0 0 -0.0957,0.6308 z m 0.238281,-1.2715 a 13,13 0 0 1 0.15625,-0.6113 13,12.999847 0 0 0 -0.15625,0.6113 z m 0.367188,-1.248 a 13,13 0 0 1 0.216796,-0.5977 13,12.999847 0 0 0 -0.216796,0.5977 z m 0.484374,-1.1934 a 13,13 0 0 1 0.285157,-0.5859 13,12.999847 0 0 0 -0.285157,0.5859 z m 0.59375,-1.1269 a 13,13 0 0 1 0.357422,-0.582 13,12.999847 0 0 0 -0.357422,0.582 z m 0.722657,-1.0918 a 13,13 0 0 1 0.394531,-0.5215 13,12.999847 0 0 0 -0.394531,0.5215 z m 0.835937,-1.0235 a 13,13 0 0 1 0.433594,-0.4667 13,12.999847 0 0 0 -0.433594,0.4667 z m 0.900391,-0.9003 a 13,13 0 0 1 0.501953,-0.4414 13,12.999847 0 0 0 -0.501953,0.4414 z m 1.023437,-0.836 a 13,13 0 0 1 0.509766,-0.3652 13,12.999847 0 0 0 -0.509766,0.3652 z m 1.091797,-0.7226 a 13,13 0 0 1 0.541016,-0.3086 13,12.999847 0 0 0 -0.541016,0.3086 z m 12.761719,-0.2598 a 13,12.999847 0 0 0 -0.578125,-0.2813 13,13 0 0 1 0.578125,0.2813 z m -11.634766,-0.334 a 13,13 0 0 1 0.595704,-0.2676 13,12.999847 0 0 0 -0.595704,0.2676 z m 10.429688,-0.2383 a 13,12.999847 0 0 0 -0.53125,-0.1933 13,13 0 0 1 0.53125,0.1933 z m -9.242188,-0.2441 a 13,13 0 0 1 0.650391,-0.2149 13,12.999847 0 0 0 -0.650391,0.2149 z m 8.044922,-0.1836 a 13,12.999847 0 0 0 -0.662109,-0.168 13,13 0 0 1 0.662109,0.168 z m -6.800781,-0.1836 a 13,13 0 0 1 0.650391,-0.1465 13,12.999847 0 0 0 -0.650391,0.1465 z m 5.535156,-0.1289 a 13,12.999847 0 0 0 -0.634765,-0.098 13,13 0 0 1 0.634765,0.098 z m -4.253906,-0.1113 a 13,13 0 0 1 0.669922,-0.082 13,12.999847 0 0 0 -0.669922,0.082 z m 2.962891,-0.076 A 13,12.999847 0 0 0 92,1078.52 a 13,13 0 0 1 1.197266,0.061 z"
+       id="path4202"
+       inkscape:connector-curvature="0" />
+    <rect
+       ry="2"
+       y="1075.5197"
+       x="-34.000008"
+       height="7.9999466"
+       width="4"
+       id="rect4306"
+       style="opacity:1;fill:url(#linearGradient4314);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="scale(-1,1)" />
+    <rect
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4212"
+       width="4"
+       height="7.9999466"
+       x="30"
+       y="1074.5198"
+       ry="2" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4304);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4253"
+       width="4"
+       height="7.9999466"
+       x="30"
+       y="1101.5197"
+       ry="2" />
+    <rect
+       ry="2"
+       y="1100.5198"
+       x="30"
+       height="7.9999466"
+       width="4"
+       id="rect4214"
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4316);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4308"
+       width="4"
+       height="7.9999466"
+       x="1090.5197"
+       y="41.000034"
+       ry="2"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       ry="2"
+       y="-48.999973"
+       x="1089.5198"
+       height="7.9999466"
+       width="4"
+       id="rect4216"
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       transform="matrix(0,1,-1,0,0,0)"
+       ry="2"
+       y="-22.999973"
+       x="1090.5197"
+       height="7.9999466"
+       width="4"
+       id="rect4257"
+       style="opacity:1;fill:url(#linearGradient4299);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4218"
+       width="4"
+       height="7.9999466"
+       x="1089.5198"
+       y="-22.999973"
+       ry="2"
+       transform="matrix(0,1,-1,0,0,0)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4320);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4312"
+       width="4"
+       height="7.9999466"
+       x="747.90125"
+       y="804.15509"
+       ry="2"
+       transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
+    <rect
+       transform="matrix(-0.70710678,0.70710678,-0.70710678,-0.70710678,0,0)"
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4220"
+       width="4"
+       height="7.9999466"
+       x="747.19366"
+       y="-811.44849"
+       ry="2" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4289);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4261"
+       width="4"
+       height="7.9999466"
+       x="747.90076"
+       y="-786.15558"
+       ry="2"
+       transform="matrix(-0.70710678,0.70710678,-0.70710678,-0.70710678,0,0)" />
+    <rect
+       transform="matrix(-0.70710678,0.70710678,-0.70710678,-0.70710678,0,0)"
+       ry="2"
+       y="-785.44849"
+       x="747.19366"
+       height="7.9999466"
+       width="4"
+       id="rect4222"
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       transform="matrix(0.70710678,0.70710678,0.70710678,-0.70710678,0,0)"
+       ry="2"
+       y="-740.90125"
+       x="793.15509"
+       height="7.9999466"
+       width="4"
+       id="rect4310"
+       style="opacity:1;fill:url(#linearGradient4318);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       ry="2"
+       y="732.19366"
+       x="792.44849"
+       height="7.9999466"
+       width="4"
+       id="rect4224"
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)" />
+    <rect
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+       ry="2"
+       y="758.90076"
+       x="793.15558"
+       height="7.9999466"
+       width="4"
+       id="rect4265"
+       style="opacity:1;fill:url(#linearGradient4301);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#e0f7fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4226"
+       width="4"
+       height="7.9999466"
+       x="792.44849"
+       y="758.19366"
+       ry="2"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-shutdown.svg
+++ b/Lüv Dark/apps/64/system-shutdown.svg
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-shutdown.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4376"
+       inkscape:collect="always">
+      <stop
+         id="stop4378"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.85555553" />
+      <stop
+         id="stop4380"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4333">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4335" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4337" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4333"
+       id="linearGradient4237"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="27"
+       y1="1092.5197"
+       x2="27"
+       y2="1095.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4333"
+       id="radialGradient4354"
+       cx="23.001028"
+       cy="36.335003"
+       fx="23.001028"
+       fy="36.335003"
+       r="0.99956006"
+       gradientTransform="matrix(-2.0008807,-4.6292263e-7,6.9434702e-7,-3.0013221,71.022289,143.05306)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4376"
+       id="radialGradient4360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0183326,1.7223595,-1.9829265,-1.1723909,124.84904,1107.1479)"
+       cx="23.001328"
+       cy="36.002346"
+       fx="23.001328"
+       fy="36.002346"
+       r="0.99956006" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4333"
+       id="linearGradient4362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,-0.8660254,0.8660254,0.5,-929.18287,579.61832)"
+       x1="27.071695"
+       y1="1093.0813"
+       x2="27"
+       y2="1095.5197" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9.1923882"
+     inkscape:cx="49.306323"
+     inkscape:cy="34.092901"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#f44336;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#ef5350;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4354);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 25 34 L 24.072266 34 L 23.152344 35.472656 A 1.0001954 1.0001355 0 0 0 24 37.001953 L 25 37.001953 L 25 34 z "
+       id="path4344"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4237);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 25 34 L 25 37.001953 L 29 37.001953 L 29 34 L 25 34 z "
+       id="path4242"
+       transform="translate(0,1058.5196)" />
+    <path
+       id="path4356"
+       d="m 29.466843,1104.2274 -0.463843,0.8036 0.815424,1.533 a 1.0001355,1.0001954 30 0 0 1.748242,0.03 l 0.500002,-0.866 -2.599825,-1.5011 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4360);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4358"
+       d="m 29.466843,1104.2274 2.599825,1.5011 8.900332,-14.9639 c 0.254154,-1.2546 -1.933275,-1.3341 -2.899913,-2.0012 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4362);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffcdd2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 33.97092,1076.52 a 1.0001954,1.0001355 0 0 0 -0.818437,0.4708 l -10.000955,16.0005 a 1.0001954,1.0001355 0 0 0 0.847737,1.5294 l 5.000477,0 0,11.0004 a 1.0001954,1.0001355 0 0 0 1.847833,0.5293 l 10.000954,-16.0006 a 1.0001954,1.0001355 0 0 0 -0.847737,-1.5293 l -5.000477,0 0,-11.0004 A 1.0001954,1.0001355 0 0 0 33.97092,1076.52 Z"
+       id="path4192"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-suspend-hibernate.svg
+++ b/Lüv Dark/apps/64/system-suspend-hibernate.svg
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-suspend-hibernate.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <linearGradient
+       gradientTransform="translate(0,1064.5196)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="linearGradient4202"
+       x1="24"
+       y1="34"
+       x2="24"
+       y2="37"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4192">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4194" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4196" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4206"
+       cx="20"
+       cy="36.5"
+       fx="20"
+       fy="36.5"
+       r="1"
+       gradientTransform="matrix(-2,0,0,-3,62,1208.0196)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4204"
+       cx="41.5"
+       cy="35.166672"
+       fx="41.5"
+       fy="35.166672"
+       r="1"
+       gradientTransform="matrix(1.7293317e-6,2.999998,-1.9999951,1.1528856e-6,95.3331,974.01964)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7293317e-6,2.999998,-1.9999951,1.1528856e-6,112.3331,971.01964)"
+       cx="41.5"
+       cy="35.166672"
+       fx="41.5"
+       fy="35.166672"
+       r="1" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,-3,74,1205.0196)"
+       cx="20"
+       cy="36.5"
+       fx="20"
+       fy="36.5"
+       r="1" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="linearGradient4221"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(12,1061.5196)"
+       x1="24"
+       y1="34"
+       x2="24"
+       y2="37" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="55.935388"
+     inkscape:cy="49.672856"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#7e57c2;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#9575cd;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#radialGradient4204);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25,1098.5196 0,3 1,0 c 0.55397,0 1,-0.446 1,-1 l 0,-2 -2,0 z"
+       id="path4184" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#radialGradient4206);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22,1098.5196 -2,0 0,2 c 0,0.554 0.44603,1 1,1 l 1,0 0,-3 z"
+       id="path4182" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22,1098.5196 0,3 3,0 0,-3 z"
+       id="rect4169"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4211"
+       d="m 42,1095.5196 0,3 1,0 c 0.55397,0 1,-0.446 1,-1 l 0,-2 -2,0 z"
+       style="opacity:1;fill:url(#radialGradient4217);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4213"
+       d="m 34,1095.5196 -2,0 0,2 c 0,0.554 0.44603,1 1,1 l 1,0 0,-3 z"
+       style="opacity:1;fill:url(#radialGradient4219);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       id="path4215"
+       d="m 34,1095.5196 0,3 8,0 0,-3 z"
+       style="opacity:1;fill:url(#linearGradient4221);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#ede7f6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.52777782"
+       d="m 33,1082.5198 c -0.553971,0 -1,0.446 -1,1 l 0,3 c 0,0.554 0.446029,1 1,1 l 5,0 -6,5 0,1 0,3 c 0,0.554 0.446029,1 1,1 l 10,0 c 0.553971,0 1,-0.446 1,-1 l 0,-3 c 0,-0.554 -0.446029,-1 -1,-1 l -5,0 6,-5 0,-1 0,-3 c 0,-0.554 -0.446029,-1 -1,-1 z m -12,9 c -0.553971,0 -1,0.446 -1,1 l 0,1 c 0,0.554 0.44672,1.0277 1,1 l 2,0 -3,3 0,1 0,1 c 0,0.554 0.446029,1 1,1 l 5,0 c 0.553971,0 1,-0.446 1,-1 l 0,-1 c 0,-0.554 -0.446029,-1 -1,-1 l -2,0 3,-3 0,-1 0,-1 c 0,-0.554 -0.446029,-1 -1,-1 z"
+       id="rect4162"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssscccsssssscccssssssscccsssssscccsss" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-suspend.svg
+++ b/Lüv Dark/apps/64/system-suspend.svg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-suspend.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4192">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4194" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4196" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="linearGradient4202"
+       x1="33"
+       y1="34"
+       x2="33"
+       y2="37"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4204"
+       cx="41.5"
+       cy="35.166672"
+       fx="41.5"
+       fy="35.166672"
+       r="1"
+       gradientTransform="matrix(1.7293317e-6,2.999998,-1.9999951,1.1528856e-6,112.3331,-90.499957)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="radialGradient4206"
+       cx="20"
+       cy="36.5"
+       fx="20"
+       fy="36.5"
+       r="1"
+       gradientTransform="matrix(-2,0,0,-3,62,143.5)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13"
+     inkscape:cx="19.538462"
+     inkscape:cy="32"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#5c6bc0;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#7986cb;fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4204);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 42 34 L 42 37 L 43 37 C 43.55397 37 44 36.55397 44 36 L 44 34 L 42 34 z "
+       id="path4184"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4206);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 22 34 L 20 34 L 20 36 C 20 36.55397 20.44603 37 21 37 L 22 37 L 22 34 z "
+       id="path4182"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4202);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 22 34 L 22 37 L 42 37 L 42 34 L 22 34 z "
+       id="rect4169"
+       transform="translate(0,1058.5196)" />
+    <rect
+       style="opacity:1;fill:#e8eaf6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4165"
+       width="6"
+       height="24"
+       x="-1094.5198"
+       y="-44"
+       ry="0.99994665"
+       transform="matrix(0,-1,-1,0,0,0)" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/system-switch-user.svg
+++ b/Lüv Dark/apps/64/system-switch-user.svg
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="system-switch-user.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4166" />
+      <stop
+         id="stop4220"
+         offset="0.83333331"
+         style="stop-color:#000000;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4168" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4170"
+       cx="32"
+       cy="1093.5195"
+       fx="32"
+       fy="1093.5195"
+       r="25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9984,9.3725632e-6,-9.7630867e-6,1.04,0.06187664,-43.74134)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4434">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.58725488"
+         offset="0"
+         id="stop4436" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4438" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,-1.522641e-6,1.5225279e-6,-1.9998514,62.998334,3270.73)"
+       r="1"
+       fy="1092.6863"
+       fx="20.999998"
+       cy="1092.6863"
+       cx="20.999998"
+       id="radialGradient4207"
+       xlink:href="#linearGradient4434"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1095.5197"
+       x2="28"
+       y1="1093.5197"
+       x1="28"
+       id="linearGradient4217"
+       xlink:href="#linearGradient4434"
+       inkscape:collect="always"
+       gradientTransform="translate(0,-7.999992)" />
+    <linearGradient
+       gradientTransform="translate(0,-7)"
+       gradientUnits="userSpaceOnUse"
+       y2="1095.8732"
+       x2="40.054394"
+       y1="1093.6222"
+       x1="38.374481"
+       id="linearGradient4229"
+       xlink:href="#linearGradient4434"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.9999921,9.163951e-6,-8.7899131e-6,-3.9999707,169.95091,1256.5586)"
+       r="0.50000268"
+       fy="41.510124"
+       fx="33.737705"
+       cy="41.510124"
+       cx="33.737705"
+       id="radialGradient4432"
+       xlink:href="#linearGradient4434"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4434"
+       id="linearGradient4278"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-64.000001,7.000008)"
+       x1="28"
+       y1="1093.5197"
+       x2="28"
+       y2="1095.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4434"
+       id="radialGradient4280"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,-1.522641e-6,1.5225279e-6,-1.9998514,-1.001667,3285.73)"
+       cx="20.999998"
+       cy="1092.6863"
+       fx="20.999998"
+       fy="1092.6863"
+       r="1" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4434"
+       id="radialGradient4282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.9999921,9.163951e-6,8.7899131e-6,-3.9999707,-105.95091,1271.5586)"
+       cx="33.737705"
+       cy="41.510124"
+       fx="33.737705"
+       fy="41.510124"
+       r="0.50000268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4434"
+       id="linearGradient4284"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,64.000001,8)"
+       x1="38.374481"
+       y1="1093.6222"
+       x2="40.054394"
+       y2="1095.8732" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="64.319423"
+     inkscape:cy="7.1140071"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+    <sodipodi:guide
+       position="5,41.000002"
+       orientation="1,0"
+       id="guide4174" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <circle
+       r="26"
+       cy="1093.5198"
+       cx="32"
+       id="circle4162"
+       style="opacity:1;fill:url(#radialGradient4170);fill-opacity:1;stroke:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#66bb6a;fill-opacity:1;stroke:none;stroke-opacity:1"
+       id="path4160"
+       cx="32"
+       cy="1091.5194"
+       r="26" />
+    <circle
+       r="25"
+       cy="-1091.5198"
+       cx="32"
+       id="circle4251"
+       style="opacity:1;fill:#81c784;fill-opacity:1;stroke:none;stroke-opacity:1"
+       transform="scale(1,-1)" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4217);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4209"
+       width="13"
+       height="3"
+       x="21"
+       y="1084.5197" />
+    <rect
+       style="opacity:1;fill:url(#radialGradient4207);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4193"
+       width="2"
+       height="3.0000534"
+       x="19"
+       y="1084.5197"
+       ry="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4432);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 34,1089.5196 0,1.998 0,0 c 0.0038,0.5073 0.387928,1.0022 1,1 l 0,-1 0,-1.2617 0,-0.7383 -1,0 z"
+       id="path4430" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4229);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 44,1083.5196 a 0.99651976,0.99659913 0 0 0 -0.617188,0.2188 L 35,1090.2579 l 0,2.2617 a 0.99651976,0.99659913 0 0 0 0.638672,-0.2344 l 8.966797,-6.9746 A 0.99651976,0.99659913 0 0 0 44,1083.5196 Z"
+       id="path4219" />
+    <path
+       style="opacity:1;fill:#e8f5e9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.960498,1075.5197 c -0.537005,0.021 -0.961296,0.4626 -0.960938,1 l 0,4 -14,0 c -0.55397,0 -1,0.446 -1,1 l 0,4 c 0,0.5539 0.44603,1 1,1 l 14,0 0,4 c 8.05e-4,0.8312 0.956494,1.2987 1.613281,0.789 l 9.001953,-7 c 0.514196,-0.4003 0.514196,-1.1777 0,-1.5781 l -9.001953,-7 c -0.185814,-0.1449 -0.416802,-0.2196 -0.652343,-0.2109 z"
+       id="rect4186"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="1099.5194"
+       x="-43"
+       height="3"
+       width="13"
+       id="rect4268"
+       style="opacity:1;fill:url(#linearGradient4278);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="scale(-1,1)" />
+    <rect
+       ry="0"
+       y="1099.5194"
+       x="-45"
+       height="3.0000534"
+       width="2"
+       id="rect4270"
+       style="opacity:1;fill:url(#radialGradient4280);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="scale(-1,1)" />
+    <path
+       id="path4272"
+       d="m 30.000001,1104.5196 0,1.998 0,0 c -0.0038,0.5073 -0.387928,1.0022 -1,1 l 0,-1 0,-1.2617 0,-0.7383 1,0 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient4282);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4274"
+       d="m 20.000001,1098.5196 a 0.99651976,0.99659913 0 0 1 0.617188,0.2188 l 8.382812,6.5195 0,2.2617 a 0.99651976,0.99659913 0 0 1 -0.638672,-0.2344 l -8.966797,-6.9746 a 0.99651976,0.99659913 0 0 1 0.605469,-1.791 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4284);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4276"
+       d="m 29.039503,1090.5197 c 0.537005,0.021 0.961296,0.4626 0.960938,1 l 0,4 14,0 c 0.55397,0 1,0.446 1,1 l 0,4 c 0,0.5539 -0.44603,1 -1,1 l -14,0 0,4 c -8.05e-4,0.8312 -0.956494,1.2987 -1.613281,0.789 l -9.001953,-7 c -0.514196,-0.4003 -0.514196,-1.1777 0,-1.5781 l 9.001953,-7 c 0.185814,-0.1449 0.416802,-0.2196 0.652343,-0.2109 z"
+       style="opacity:1;fill:#e8f5e9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/utilities-file-archiver.svg
+++ b/Lüv Dark/apps/64/utilities-file-archiver.svg
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="ark.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,17.99984,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,139.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4226"
+       id="linearGradient4224"
+       x1="32"
+       y1="1099.5197"
+       x2="32"
+       y2="1109.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-3)" />
+    <linearGradient
+       id="linearGradient4226"
+       inkscape:collect="always">
+      <stop
+         id="stop4228"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.19607843" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30980393"
+         offset="0.79999465"
+         id="stop4232" />
+      <stop
+         id="stop4230"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="26"
+     inkscape:cx="33.803224"
+     inkscape:cy="15.096606"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <rect
+       ry="1.9999467"
+       y="1070.5198"
+       x="18"
+       height="32"
+       width="28"
+       id="rect4183"
+       style="opacity:1;fill:#ffca28;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       ry="0.99994665"
+       y="1071.5198"
+       x="19"
+       height="30"
+       width="26"
+       id="rect4185"
+       style="opacity:1;fill:#ffd54f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#66bb6a;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4179"
+       width="28"
+       height="32"
+       x="11"
+       y="1074.5197"
+       ry="1.9999467" />
+    <rect
+       style="opacity:1;fill:#81c784;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4181"
+       width="26"
+       height="30"
+       x="12"
+       y="1075.5197"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#5c6bc0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4187"
+       width="28"
+       height="32"
+       x="25"
+       y="1078.5198"
+       ry="1.9999467" />
+    <rect
+       style="opacity:1;fill:#7986cb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4189"
+       width="26"
+       height="30"
+       x="26"
+       y="1079.5198"
+       ry="0.99994665" />
+    <path
+       id="path4249-5"
+       d="m 54,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 10,1115.5196 0,4 44,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 7,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#a97b50;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9 24 C 7.892 24 7 24.892 7 26 L 7 27 L 7 43 L 7 56 C 7 57.662039 8.3379612 59 10 59 L 54 59 C 55.662039 59 57 57.662039 57 56 L 57 43 L 57 27 L 57 26 C 57 24.892 56.108 24 55 24 L 54 24 L 10 24 L 9 24 z "
+       transform="translate(0,1058.5196)"
+       id="rect4208" />
+    <path
+       style="opacity:1;fill:#c49a6c;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9 25 C 8.4460296 25 8 25.44603 8 26 L 8 27 L 8 46 L 8 56 C 8 57.10797 8.8920295 58 10 58 L 54 58 C 55.10797 58 56 57.10797 56 56 L 56 46 L 56 27 L 56 26 C 56 25.44603 55.55397 25 55 25 L 54 25 L 10 25 L 9 25 z "
+       transform="translate(0,1058.5196)"
+       id="rect4173" />
+    <path
+       style="opacity:1;fill:#95683f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29,1083.5196 0,12 c 0,1.662 1.338028,3 3,3 1.661972,0 3,-1.338 3,-3 l 0,-12 -6,0 z"
+       id="rect4211"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#c49a6c;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 30,1083.5196 0,12 c 0,1.108 0.892,2 2,2 1.108,0 2,-0.892 2,-2 l 0,-12 -4,0 z"
+       id="rect4168"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4216"
+       d="m 32,1096.5196 a 2,2 0 0 0 -2,2 l 0,6 a 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 l 0,-6 a 2,2 0 0 0 -2,-2 z m 0,7 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z"
+       style="opacity:1;fill:url(#linearGradient4224);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32,1095.5196 a 2,2 0 0 0 -2,2 l 0,6 a 2,2 0 0 0 2,2 2,2 0 0 0 2,-2 l 0,-6 a 2,2 0 0 0 -2,-2 z m 0,7 a 1,1 0 0 1 1,1 1,1 0 0 1 -1,1 1,1 0 0 1 -1,-1 1,1 0 0 1 1,-1 z"
+       id="path4185"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="1083.5201"
+       x="32.000004"
+       height="2"
+       width="2"
+       id="rect4199"
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4201"
+       width="2"
+       height="2"
+       x="29.999996"
+       y="1085.5201" />
+    <rect
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4203"
+       width="2"
+       height="2"
+       x="32.000004"
+       y="1087.5201" />
+    <rect
+       y="1089.5201"
+       x="29.999996"
+       height="2"
+       width="2"
+       id="rect4205"
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="1091.5201"
+       x="32.000004"
+       height="2"
+       width="2"
+       id="rect4207"
+       style="opacity:1;fill:#eeeeee;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4209"
+       width="2"
+       height="2"
+       x="29.999996"
+       y="1093.5201" />
+    <rect
+       style="opacity:1;fill:#eceff1;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4397-2"
+       width="13.000008"
+       height="5.9998093"
+       x="41"
+       y="1108.5197"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4399-5"
+       width="1.9999924"
+       height="4.0001907"
+       x="42.000008"
+       y="1109.5194"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4182"
+       width="1"
+       height="4"
+       x="45"
+       y="1109.5197" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4184"
+       width="1"
+       height="4"
+       x="47"
+       y="1109.5197" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4186"
+       width="2"
+       height="4"
+       x="49"
+       y="1109.5197" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4188"
+       width="1"
+       height="4"
+       x="52"
+       y="1109.5197" />
+    <path
+       style="opacity:1;fill:#a97b50;fill-opacity:1;stroke:none;stroke-width:2.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15 47 L 13 50 L 14 50 L 14 54 L 16 54 L 16 50 L 17 50 L 15 47 z M 17 50 L 18 50 L 18 54 L 20 54 L 20 50 L 21 50 L 19 47 L 17 50 z M 12 55 L 12 56 L 22 56 L 22 55 L 12 55 z "
+       id="rect4190"
+       transform="translate(0,1058.5196)" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/utilities-system-monitor.svg
+++ b/Lüv Dark/apps/64/utilities-system-monitor.svg
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="utilities-system-monitor.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,14.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4166"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000003,-2.935184e-6,-3.9135795e-6,-2.6666677,49.00016,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4241"
+       x1="20"
+       y1="1083.5197"
+       x2="20"
+       y2="1085.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4276"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="32"
+       y1="1082.5197"
+       x2="32"
+       y2="1085.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4281"
+       cx="28.03688"
+       cy="20.251009"
+       fx="28.03688"
+       fy="20.251009"
+       r="1.5"
+       gradientTransform="matrix(-2.0000003,4.0350247e-7,-3.6402565e-7,-2.0000003,87.073776,64.502013)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000003,5.5236982e-7,5.1285266e-7,-1.9998927,-23.073779,1123.0196)"
+       cx="28.03688"
+       cy="20.251009"
+       fx="28.03688"
+       fy="20.251009"
+       r="1.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4300"
+       cx="24.5"
+       cy="20"
+       fx="24.5"
+       fy="20"
+       r="1.5"
+       gradientTransform="matrix(-9.1111153e-7,1.3333335,-1.3333333,-9.111114e-7,50.666689,-11.666655)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4317"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="23"
+       y1="1079.5197"
+       x2="23"
+       y2="1081.5197" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4327"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="23"
+       y1="1075.5197"
+       x2="23"
+       y2="1077.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4334"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-9.1111153e-7,1.3333335,-1.3333333,-9.111114e-7,50.666689,-11.666655)"
+       cx="21.500002"
+       cy="20.000002"
+       fx="21.500002"
+       fy="20.000002"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="14"
+       y1="1082.5197"
+       x2="14"
+       y2="1085.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4357"
+       cx="15.07529"
+       cy="19.049137"
+       fx="15.07529"
+       fy="19.049137"
+       r="1.2666014"
+       gradientTransform="matrix(-6.6324984e-7,1.579029,-1.5790292,-6.3113016e-7,45.079155,-6.8043076)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1058.5196)"
+       x1="14"
+       y1="1075.5197"
+       x2="14"
+       y2="1077.5197" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4363"
+       cx="12.333338"
+       cy="18.998844"
+       fx="12.333338"
+       fy="18.998844"
+       r="2"
+       gradientTransform="matrix(-1.5,-8.8976801e-8,8.8976891e-8,-1.5,31.500005,52.498268)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4365"
+       cx="14.305916"
+       cy="25.767641"
+       fx="14.305916"
+       fy="25.767641"
+       r="1.2666015"
+       gradientTransform="matrix(7.6628565e-7,2.3685427,-1.5790292,5.349947e-7,55.687847,-9.8841854)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4373"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000002,2.2568749e-7,-1.1284378e-7,-1.000001,37.666682,40.665531)"
+       cx="12.833339"
+       cy="23.66551"
+       fx="12.833339"
+       fy="23.66551"
+       r="2" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.653436"
+     inkscape:cx="20.513415"
+     inkscape:cy="40.543074"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.7;fill:url(#radialGradient4166);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 60,1115.5196 0,2 c 0,1.108 -0.892,2 -2,2 l -1,0 0,-4 3,0 z"
+       id="path4164" />
+    <path
+       id="path4251-7"
+       d="m 6.999995,1115.5196 0,4 50,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 3.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#37474f;fill-opacity:1"
+       id="rect3362"
+       width="56"
+       height="47.999931"
+       x="4"
+       y="1069.5197"
+       ry="2.9999466" />
+    <rect
+       style="opacity:1;fill:#455a64;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4166"
+       width="54"
+       height="46"
+       x="5"
+       y="1070.5197"
+       ry="1.9999467" />
+    <path
+       style="fill:#26c6da;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 53,30 -16,9 -2,-1 -3,-2 -4,-1 -13,7 -5,-2 -5,4 0,12 c 0,1.10797 0.8920295,2 2,2 l 50,0 c 1.10797,0 2,-0.89203 2,-2 l 0,-25 -4,1 z"
+       transform="translate(0,1058.5196)"
+       id="path4355"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccssssccc" />
+    <path
+       style="fill:#4dd0e1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 28,1093.5196 0,23 9,0 0,-19 -5,-3 z"
+       id="path4360"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#4dd0e1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 53,30 0,28 4,0 c 1.10797,0 2,-0.89203 2,-2 l 0,-25 -4,1 z"
+       transform="translate(0,1058.5196)"
+       id="path4362"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssccc" />
+    <path
+       style="fill:#00bcd4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10,40 -5,4 0,12 c 0,1.10797 0.8920295,2 2,2 l 3,0 z"
+       transform="translate(0,1058.5196)"
+       id="path4367"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscc" />
+    <path
+       style="fill:#00acc1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 59 31 L 58 31.25 L 58 56 C 58 56.55397 57.55397 57 57 57 L 7 57 C 6.4460296 57 6 56.55397 6 56 L 6 43.199219 L 5 44 L 5 56 C 5 57.10797 5.8920295 58 7 58 L 57 58 C 58.10797 58 59 57.10797 59 56 L 59 31 z "
+       transform="translate(0,1058.5196)"
+       id="path4166" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4365);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15 24.822266 L 15 26.896484 A 4.999999 4.999999 0 0 0 17.533203 25.533203 L 16.119141 24.119141 A 2.999999 2.999999 0 0 1 15 24.822266 z "
+       id="path4346"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4348);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13 24.824219 L 13 26.894531 A 4.999999 4.999999 0 0 0 14 27 A 4.999999 4.999999 0 0 0 15 26.896484 L 15 24.822266 A 2.999999 2.999999 0 0 1 14 25 A 2.999999 2.999999 0 0 1 13 24.824219 z "
+       id="path4353"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4363);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.175781 21 L 9.1074219 21 A 4.999999 4.999999 0 0 0 9 22 A 4.999999 4.999999 0 0 0 13 26.894531 L 13 24.824219 A 2.999999 2.999999 0 0 1 11 22 A 2.999999 2.999999 0 0 1 11.175781 21 z "
+       id="path4371"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4373);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13 17.101562 A 4.999999 4.999999 0 0 0 9.1074219 21 L 11.175781 21 A 2.999999 2.999999 0 0 1 13 19.173828 L 13 17.101562 z "
+       id="path4351"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4359);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13 17.101562 L 13 19.173828 A 2.999999 2.999999 0 0 1 14 19 A 2.999999 2.999999 0 0 1 15 19.175781 L 15 17.105469 A 4.999999 4.999999 0 0 0 14 17 A 4.999999 4.999999 0 0 0 13 17.101562 z "
+       id="path4344"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4357);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15 17.105469 L 15 19.175781 A 2.999999 2.999999 0 0 1 16.119141 19.880859 L 17.533203 18.466797 A 4.999999 4.999999 0 0 0 15 17.105469 z "
+       id="path4233"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14,1074.5196 a 4.999999,4.999999 0 0 0 -5,5 4.999999,4.999999 0 0 0 5,5 4.999999,4.999999 0 0 0 3.533203,-1.4668 l -1.414062,-1.4141 A 2.999999,2.999999 0 0 1 14,1082.5196 a 2.999999,2.999999 0 0 1 -3,-3 2.999999,2.999999 0 0 1 3,-3 2.999999,2.999999 0 0 1 2.119141,0.8809 l 1.414062,-1.4141 A 4.999999,4.999999 0 0 0 14,1074.5196 Z"
+       id="path4200"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4317);fill-opacity:1.0;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21 21 L 21 23 L 22 23 L 24 23 L 24 21 L 22 21 L 21 21 z "
+       id="path4315"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4241);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21 17 L 19 17 L 19 20 L 19 27 L 21 27 L 21 23 L 21 21 L 21 20 L 21 19 L 21 17 z "
+       id="path4313"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4327);fill-opacity:1.0;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21 17 L 21 19 L 22 19 L 24 19 L 24 17 L 22 17 L 21 17 z "
+       id="path4298"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4300);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 25 20 C 25 20.554 24.553985 21 24 21 L 24 23 C 25.661985 23 27 21.662 27 20 L 25 20 z "
+       transform="translate(0,1058.5196)"
+       id="path4332" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4334);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 24 17 L 24 19 L 26.587891 19 C 26.14917 17.888901 25.270702 17 24 17 z "
+       id="path4235"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19,1074.5196 0,3 0,7 2,0 0,-4 1,0 2,0 c 1.661985,0 3,-1.338 3,-3 0,-1.662 -1.338015,-3 -3,-3 l -2,0 -1,0 -2,0 z m 2,2 1,0 2,0 c 0.553985,0 1,0.446 1,1 0,0.554 -0.446015,1 -1,1 l -2,0 -1,0 0,-1 0,-1 z"
+       id="rect4208"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:url(#linearGradient4276);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 31 24.587891 L 31 26.798828 C 31.327324 26.884869 31.644933 27 32 27 C 32.355067 27 32.672676 26.884869 33 26.798828 L 33 24.587891 C 32.692406 24.780524 32.391197 25 32 25 C 31.608803 25 31.307594 24.780524 31 24.587891 z "
+       id="path4279"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:url(#radialGradient4281);fill-opacity:1.0;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 28 17 L 28 21 L 28 23 C 28 24.860933 29.284471 26.347883 31 26.798828 L 31 24.587891 C 30.436385 24.234922 30 23.716803 30 23 L 30 22 L 30 18 L 30 17 L 28 17 z "
+       id="path4237"
+       transform="translate(0,1058.5196)" />
+    <path
+       id="path4291"
+       d="m 36,1075.5196 0,4.0001 0,2 c 0,1.861 -1.284471,3.348 -3,3.7989 l 0,-2.2109 c 0.563615,-0.3531 1,-0.8712 1,-1.588 l 0,-1 0,-4.0001 0,-1 2,0 z"
+       style="opacity:1;fill:url(#radialGradient4293);fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 28,1074.5196 0,4 0,2 c 0,2.216 1.784,4 4,4 2.216,0 4,-1.784 4,-4 l 0,-2 0,-4 -2,0 0,1 0,4 0,1 c 0,1.108 -0.892,2 -2,2 -1.108,0 -2,-0.892 -2,-2 l 0,-1 0,-4 0,-1 -2,0 z"
+       id="rect4222"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/utilities-terminal.svg
+++ b/Lüv Dark/apps/64/utilities-terminal.svg
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="utilities-terminal.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,14.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <linearGradient
+       id="linearGradient4228"
+       inkscape:collect="always">
+      <stop
+         id="stop4230"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.19607843" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.19607843"
+         offset="0.69999468"
+         id="stop4240" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.11764706"
+         offset="0.79999465"
+         id="stop4238" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30980393"
+         offset="0.89999467"
+         id="stop4236" />
+      <stop
+         id="stop4232"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1080.5197"
+       x2="20"
+       y1="1070.5197"
+       x1="20"
+       id="linearGradient4234-7"
+       xlink:href="#linearGradient4228"
+       inkscape:collect="always"
+       gradientTransform="translate(-6,11)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4166"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0000003,-2.935184e-6,-3.9135795e-6,-2.6666677,49.00016,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="18.340582"
+     inkscape:cx="29.93204"
+     inkscape:cy="9.7408833"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1021"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.7;fill:url(#radialGradient4166);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 60,1115.5196 0,2 c 0,1.108 -0.892,2 -2,2 l -1,0 0,-4 3,0 z"
+       id="path4164" />
+    <path
+       id="path4251-7"
+       d="m 6.999995,1115.5196 0,4 50,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 3.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#37474f;fill-opacity:1"
+       id="rect3362"
+       width="56"
+       height="47.999931"
+       x="4"
+       y="1069.5197"
+       ry="2.9999466" />
+    <path
+       style="fill:#455a64;fill-opacity:1"
+       d="M 5 17 L 5 56 C 5 57.10797 5.8920295 58 7 58 L 10 58 L 57 58 C 58.10797 58 59 57.10797 59 56 L 59 17 L 10 17 L 5 17 z "
+       transform="translate(0,1058.5196)"
+       id="path3376" />
+    <path
+       style="fill:#e0e0e0;fill-opacity:1"
+       d="M 7 12 C 5.8920295 12 5 12.89203 5 14 L 5 17 L 59 17 L 59 14 C 59 12.89203 58.10797 12 57 12 L 7 12 z "
+       id="rect3364"
+       transform="translate(0,1058.5196)" />
+    <circle
+       style="fill:#ef5350;fill-opacity:1"
+       id="path3371"
+       cx="55.5"
+       cy="1073.0197"
+       r="1.5" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4226-6"
+       d="m 11,1081.5196 0,2 -2,0 0,2 2,0 0,2 -2,0 0,2 2,0 0,2 2,0 0,-2 2,0 0,2 2,0 0,-2 2,0 0,-2 -2,0 0,-2 2,0 0,-2 -2,0 0,-2 -2,0 0,2 -2,0 0,-2 -2,0 z m 10,0 0,7 2,0 0,-7 -2,0 z m -8,4 2,0 0,2 -2,0 0,-2 z m 8,4 0,2 2,0 0,-2 -2,0 z"
+       style="opacity:1;fill:url(#linearGradient4234-7);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#b0bec5;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11,1080.5196 0,2 -2,0 0,2 2,0 0,2 -2,0 0,2 2,0 0,2 2,0 0,-2 2,0 0,2 2,0 0,-2 2,0 0,-2 -2,0 0,-2 2,0 0,-2 -2,0 0,-2 -2,0 0,2 -2,0 0,-2 -2,0 z m 10,0 0,7 2,0 0,-7 -2,0 z m -8,4 2,0 0,2 -2,0 0,-2 z m 8,4 0,2 2,0 0,-2 -2,0 z"
+       id="rect4183-1"
+       inkscape:connector-curvature="0" />
+    <circle
+       r="0.5"
+       cy="1073.0197"
+       cx="55.5"
+       id="circle3505"
+       style="fill:#ef9a9a;fill-opacity:1" />
+    <rect
+       style="fill:#37474f;fill-opacity:1"
+       id="rect3507"
+       width="54"
+       height="1"
+       x="5"
+       y="1075.5197"
+       ry="0" />
+  </g>
+</svg>

--- a/Lüv Dark/apps/64/utilities-text-editor.svg
+++ b/Lüv Dark/apps/64/utilities-text-editor.svg
@@ -1,0 +1,430 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kate.svg"
+   inkscape:export-filename="/home/uri/kate-flattr.png"
+   inkscape:export-xdpi="360"
+   inkscape:export-ydpi="360">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,21.999835,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,135.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4396"
+       cx="16.5"
+       cy="1086.0197"
+       fx="16.5"
+       fy="1086.0197"
+       r="2.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2.0000005)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4396-2"
+       cx="16.5"
+       cy="1086.0197"
+       fx="16.5"
+       fy="1086.0197"
+       r="2.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(12,17.000464)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4432"
+       x1="17"
+       y1="1093.5197"
+       x2="17"
+       y2="1098.5197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,1.0000004)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13"
+     inkscape:cx="32"
+     inkscape:cy="32"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 49.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 14,1115.5196 0,4 36,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 10.999995,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#b0bec5;fill-opacity:1"
+       id="rect3360"
+       width="42"
+       height="51.999947"
+       x="11"
+       y="1065.5195"
+       ry="2.9999466" />
+    <path
+       style="fill:#fafafa;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 52,1082.5196 -40,0 0,32 c 0,1.108 0.89203,2 2,2 l 36,0 c 1.10797,0 2,-0.892 2,-2 l 0,-32 z"
+       id="path4365"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#eceff1;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 12,1071.5196 0,11 40,0 0,-11 -40,0 z"
+       id="path4220"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#cfd8dc;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 14,1066.5196 c -1.10797,0 -2,0.892 -2,2 l 0,3 40,0 0,-3 c 0,-1.108 -0.89203,-2 -2,-2 l -36,0 z"
+       id="rect4215"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#b0bec5;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4222"
+       width="41"
+       height="1"
+       x="11"
+       y="1071.5195"
+       ry="0" />
+    <rect
+       style="fill:#80deea;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4228"
+       width="12.999996"
+       height="8.0001907"
+       x="16.000004"
+       y="1090.5193"
+       ry="0" />
+    <rect
+       style="fill:#b2ebf2;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4230"
+       width="8.9999962"
+       height="6.0001907"
+       x="18.000008"
+       y="1091.5193" />
+    <circle
+       style="fill:url(#radialGradient4396);fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4388"
+       cx="16.5"
+       cy="1088.0193"
+       r="2.5" />
+    <path
+       style="fill:#00bcd4;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 16.5,1084.5196 c -1.380712,0 -2.5,1.1193 -2.5,2.5 1.28e-4,1.1879 0.836122,2.2116 2,2.4492 l 0,9.0508 1,0 0,-9.0547 c 1.162442,-0.2373 1.998017,-1.2589 2,-2.4453 0,-1.3807 -1.119288,-2.5 -2.5,-2.5 z"
+       id="path4224"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccs" />
+    <circle
+       style="fill:url(#radialGradient4396-2);fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4388-1"
+       cx="28.5"
+       cy="1103.0193"
+       r="2.5" />
+    <rect
+       style="fill:url(#linearGradient4432);fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4422"
+       width="13"
+       height="0.99994665"
+       x="16"
+       y="1098.5195" />
+    <path
+       id="path4237"
+       d="m 28.5,1104.5196 c -1.380712,0 -2.5,-1.1193 -2.5,-2.5 1.37e-4,-1.1879 0.836129,-2.2116 2,-2.4492 l 0,-9.0508 1,0 0,9.0547 c 1.162437,0.2373 1.998012,1.2589 2,2.4453 0,1.3807 -1.119288,2.5 -2.5,2.5 z"
+       style="fill:#00bcd4;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccs" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4243"
+       width="2"
+       height="0.99994665"
+       x="12.999998"
+       y="1075.5195" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4245"
+       width="3"
+       height="0.99994665"
+       x="12.999998"
+       y="1077.5195" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4247"
+       width="3"
+       height="0.99994665"
+       x="16.999996"
+       y="1075.5195" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4249"
+       width="3"
+       height="1.0000533"
+       x="16.999996"
+       y="1077.5195" />
+    <rect
+       y="1075.5195"
+       x="-24"
+       height="0.99994665"
+       width="2"
+       id="rect4251"
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       transform="scale(-1,1)" />
+    <rect
+       y="1077.5195"
+       x="-24"
+       height="0.99994665"
+       width="3.0000038"
+       id="rect4253"
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       transform="scale(-1,1)" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4255"
+       width="1.0000001"
+       height="3"
+       x="26.999998"
+       y="1075.5195" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4257"
+       width="2.0000002"
+       height="0.99994665"
+       x="26.999998"
+       y="1075.5195"
+       ry="0.49036145" />
+    <rect
+       ry="0.99994665"
+       y="1076.5195"
+       x="26.999998"
+       height="2.0000534"
+       width="3.0000005"
+       id="rect4259"
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 31,1075.5196 0,1.5 c 0,0.831 0.669,1.5 1.5,1.5 0.831,0 1.5,-0.669 1.5,-1.5 l 0,-1.5 -1,0 0,1.5 0,0.5 -1,0 0,-0.5 0,-1.4082 0,-0.092 -1,0 z"
+       id="rect4263"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 36.284767,1075.5196 -0.804689,3 1.035157,0 0.804688,-3 -1.035156,0 z"
+       id="rect4276"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4281"
+       width="2.400001"
+       height="1"
+       x="35.299995"
+       y="1075.5195" />
+    <rect
+       y="1077.519"
+       x="35"
+       height="1"
+       width="2.400001"
+       id="rect4283"
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <circle
+       style="fill:#ef5350;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path4285"
+       cx="49.5"
+       cy="1069.0195"
+       r="1.5" />
+    <circle
+       r="0.5"
+       cy="1069.0195"
+       cx="49.5"
+       id="circle4346"
+       style="fill:#ef9a9a;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <rect
+       style="fill:#b0bec5;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4348"
+       width="10"
+       height="5.0000534"
+       x="41"
+       y="1074.5195"
+       ry="0.99994665" />
+    <rect
+       style="fill:#cfd8dc;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4350"
+       width="8"
+       height="3"
+       x="42"
+       y="1075.5195"
+       ry="0" />
+    <rect
+       style="fill:#455a64;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4352"
+       width="1"
+       height="1"
+       x="48"
+       y="1076.5195" />
+    <rect
+       style="fill:#90a4ae;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4354"
+       width="4"
+       height="1"
+       x="43"
+       y="1076.5195" />
+    <rect
+       style="fill:#cfd8dc;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4356"
+       width="40"
+       height="1"
+       x="12"
+       y="1081.5193" />
+    <rect
+       style="fill:#cfd8dc;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4358"
+       width="1"
+       height="2.9999466"
+       x="25"
+       y="1075.5195" />
+    <rect
+       style="fill:#cfd8dc;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       id="rect4360"
+       width="1"
+       height="2.9999466"
+       x="39"
+       y="1075.5195" />
+    <path
+       style="fill:#607d8b;fill-opacity:1;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 19,1092.5196 0,4 1,0 0,-1 1,0 0,1 1,0 0,-4 -1,0 0,2 -1,0 0,-2 -1,0 z m 4.5,0 a 0.5,0.5 0 0 0 -0.5,0.5 0.5,0.5 0 0 0 0.5,0.5 0.5,0.5 0 0 0 0.5,-0.5 0.5,0.5 0 0 0 -0.5,-0.5 z m 1.5,0 0,3 0.5,0 0.5,0 0,-3 -1,0 z m 0.5,3 a 0.5,0.5 0 0 0 -0.5,0.5 0.5,0.5 0 0 0 0.5,0.5 0.5,0.5 0 0 0 0.5,-0.5 0.5,0.5 0 0 0 -0.5,-0.5 z m -2.5,-1 0,2 1,0 0,-2 -1,0 z"
+       id="rect4367"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/devices/64/drive-harddisk.svg
+++ b/Lüv Dark/devices/64/drive-harddisk.svg
@@ -1,0 +1,429 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="alt-partitionmanager.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,22.99984,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,134.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="16"
+     inkscape:cx="49.307746"
+     inkscape:cy="32.614379"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <rect
+       style="opacity:1;fill:#9e9e9e;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4271"
+       width="22"
+       height="2.0000534"
+       x="20"
+       y="1071.5197" />
+    <path
+       sodipodi:nodetypes="ssccsss"
+       inkscape:connector-curvature="0"
+       id="path4265"
+       d="m 31,1070.5196 c -0.55397,0 -1.027665,0.4467 -1,1 l 0,2 10,0 0,-2 c 0,-0.554 -0.44603,-1 -1,-1 z"
+       style="opacity:1;fill:#fbc02d;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#fbc02d;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23,1070.5196 c -0.55397,0 -1,0.446 -1,1 l 0,2 7,0 0,-2 c 0,-0.554 -0.44603,-1 -1,-1 z"
+       id="path4255"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssccsss" />
+    <rect
+       style="opacity:1;fill:#fdd835;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4287"
+       width="6.9999943"
+       height="1.0001754"
+       x="22.000002"
+       y="-1072.5198"
+       transform="scale(1,-1)" />
+    <path
+       id="path4249-5"
+       d="m 48.999995,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 14.999995,1115.5196 0,4 34,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 12,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 14 11 C 12.89203 11 12 11.89203 12 13 L 12 57 C 12 58.10797 12.89203 59 14 59 L 50 59 C 51.10797 59 52 58.10797 52 57 L 52 13 C 52 11.89203 51.10797 11 50 11 L 44 11 L 43 11 C 41.89203 11 41 11.892 41 13 L 41 14 L 42 14 L 42 15 L 20 15 L 20 14 L 21 14 L 21 13 C 21 11.892 20.10797 11 19 11 L 18 11 L 14 11 z "
+       transform="translate(0,1058.5196)"
+       id="rect4160" />
+    <path
+       style="opacity:1;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 14 12 C 13.44603 12 13 12.44603 13 13 L 13 57 C 13 57.55397 13.44603 58 14 58 L 50 58 C 50.55397 58 51 57.55397 51 57 L 51 13 C 51 12.44603 50.55397 12 50 12 L 44 12 L 43 12 C 42.44603 12 42 12.446 42 13 L 42 15 L 20 15 L 20 13 C 20 12.446 19.55397 12 19 12 L 18 12 L 14 12 z "
+       transform="translate(0,1058.5196)"
+       id="rect4162" />
+    <path
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 12 13 L 12 16 L 15.5 16 A 1.5 1.5 0 0 0 17 14.5 A 1.5 1.5 0 0 0 15.5 13 L 12 13 z M 48.5 13 A 1.5 1.5 0 0 0 47 14.5 A 1.5 1.5 0 0 0 48.5 16 L 52 16 L 52 13 L 48.5 13 z M 12 54 L 12 57 L 15.5 57 A 1.5 1.5 0 0 0 17 55.5 A 1.5 1.5 0 0 0 15.5 54 L 12 54 z M 48.5 54 A 1.5 1.5 0 0 0 47 55.5 A 1.5 1.5 0 0 0 48.5 57 L 52 57 L 52 54 L 48.5 54 z "
+       transform="translate(0,1058.5196)"
+       id="path4166" />
+    <circle
+       r="0.5"
+       cy="1073.0197"
+       cx="15.5"
+       id="circle4168"
+       style="opacity:1;fill:#757575;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#757575;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="circle4172"
+       cx="48.499985"
+       cy="1073.0197"
+       r="0.5" />
+    <circle
+       style="opacity:1;fill:#757575;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="circle4176"
+       cx="15.5"
+       cy="1114.0194"
+       r="0.5" />
+    <circle
+       r="0.5"
+       cy="1114.0194"
+       cx="48.499985"
+       id="circle4180"
+       style="opacity:1;fill:#757575;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 47 30 L 17 30 L 17 53 C 17 53.55397 17.44603 54 18 54 L 46 54 C 46.55397 54 47 53.55397 47 53 L 47 30 z "
+       id="path4206"
+       transform="translate(0,1058.5196)" />
+    <path
+       style="opacity:1;fill:#42a5f5;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 18 16 C 17.44603 16 17 16.44603 17 17 L 17 30 L 47 30 L 47 17 C 47 16.44603 46.55397 16 46 16 L 18 16 z "
+       id="rect4191"
+       transform="translate(0,1058.5196)" />
+    <rect
+       style="opacity:1;fill:#64b5f6;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4195"
+       width="28"
+       height="11.999947"
+       x="18"
+       y="1075.5197"
+       ry="0" />
+    <rect
+       ry="0"
+       y="1089.5197"
+       x="18"
+       height="22.000053"
+       width="28"
+       id="rect4201"
+       style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       transform="scale(1,-1)"
+       y="-1072.5197"
+       x="30"
+       height="1.0000533"
+       width="10"
+       id="rect4267"
+       style="opacity:1;fill:#fdd835;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#bdbdbd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4291"
+       width="22"
+       height="0.99994665"
+       x="20"
+       y="1072.5197" />
+    <rect
+       style="opacity:1;fill:#bbdefb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4347"
+       width="19"
+       height="0.99994665"
+       x="19"
+       y="1076.5197" />
+    <rect
+       style="opacity:1;fill:#bbdefb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4349"
+       width="12"
+       height="1"
+       x="19"
+       y="1078.5197" />
+    <rect
+       style="opacity:1;fill:#bbdefb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4351"
+       width="6"
+       height="1"
+       x="19"
+       y="1080.5197" />
+    <rect
+       style="opacity:1;fill:#bbdefb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4353"
+       width="9"
+       height="1"
+       x="27"
+       y="1080.5197" />
+    <rect
+       style="opacity:1;fill:#bbdefb;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4355"
+       width="6"
+       height="1"
+       x="19"
+       y="-1084.5197"
+       transform="scale(1,-1)" />
+    <path
+       style="opacity:1;fill:#e3f2fd;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 41 24 L 41 25 L 43 25 L 43 24 L 41 24 z M 43 25 L 43 26 L 44 26 L 44 25 L 43 25 z M 43 26 L 42 26 L 41 26 L 41 27 L 42 27 L 42 28 L 43 28 L 44 28 L 44 27 L 43 27 L 43 26 z M 41 27 L 40 27 L 40 28 L 41 28 L 41 27 z M 41 26 L 41 25 L 40 25 L 40 26 L 41 26 z "
+       transform="translate(0,1058.5196)"
+       id="rect4357" />
+    <path
+       style="fill:#424242;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 43,1110.5196 -2,-3 -2,3 z"
+       id="path4371"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4192"
+       width="1"
+       height="5.0000534"
+       x="19"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4194"
+       width="2"
+       height="5.0000534"
+       x="21"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4196"
+       width="2"
+       height="5.0000534"
+       x="24"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4198"
+       width="1"
+       height="5.0000534"
+       x="27"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4203"
+       width="1"
+       height="5"
+       x="29"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#fdd835;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4397"
+       width="13"
+       height="6.0000687"
+       x="32"
+       y="1094.519"
+       ry="0.99994665" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4399"
+       width="9"
+       height="0.99970251"
+       x="33"
+       y="1095.519"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4401"
+       width="5"
+       height="1"
+       x="33"
+       y="1097.519" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4405"
+       width="1"
+       height="1.0000688"
+       x="39"
+       y="1097.519" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4436"
+       width="2"
+       height="2.0000534"
+       x="42.000015"
+       y="1097.5188"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4225"
+       width="10"
+       height="1"
+       x="20.000004"
+       y="1091.5194"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4229"
+       width="3"
+       height="1"
+       x="20.000004"
+       y="1093.5194" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4231"
+       width="7"
+       height="1"
+       x="20.000004"
+       y="1095.5194" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4233"
+       width="4"
+       height="1"
+       x="20.000004"
+       y="1097.5194" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4235"
+       width="7"
+       height="1"
+       x="32"
+       y="1105.5197" />
+    <rect
+       style="opacity:1;fill:#424242;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4237"
+       width="3"
+       height="1"
+       x="33"
+       y="1107.5197" />
+  </g>
+</svg>

--- a/Lüv Dark/devices/64/smartphone.svg
+++ b/Lüv Dark/devices/64/smartphone.svg
@@ -1,0 +1,320 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64"
+   height="64"
+   viewBox="0 0 64 64.000003"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="smartphone.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="Shadow">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4259-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0000003,-2.935184e-6,3.9135795e-6,-2.6666677,26.99984,1228.853)"
+       cx="4"
+       cy="42.5"
+       fx="4"
+       fy="42.5"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4257-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(9.999995,1073.5196)"
+       x1="24"
+       y1="42"
+       x2="24"
+       y2="46" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="radialGradient4255-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.6193702e-6,2.666668,-2.0000002,-4.214526e-6,130.00027,998.1864)"
+       cx="44"
+       cy="42.500004"
+       fx="44"
+       fy="42.500004"
+       r="1.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#Shadow"
+       id="linearGradient4184"
+       x1="30"
+       y1="1077.5197"
+       x2="30"
+       y2="1079.5197"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="39.165933"
+     inkscape:cy="40.872269"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1017"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+    <sodipodi:guide
+       position="5,59.000069"
+       orientation="54,0"
+       id="guide4142" />
+    <sodipodi:guide
+       position="5,5.0000688"
+       orientation="0,54"
+       id="guide4144" />
+    <sodipodi:guide
+       position="59,5.0000688"
+       orientation="-54,0"
+       id="guide4146" />
+    <sodipodi:guide
+       position="59,59.000069"
+       orientation="0,-54"
+       id="guide4148" />
+    <sodipodi:guide
+       position="0,64.000069"
+       orientation="64,0"
+       id="guide4150" />
+    <sodipodi:guide
+       position="0,6.875e-05"
+       orientation="0,64"
+       id="guide4152" />
+    <sodipodi:guide
+       position="64,4.0000002"
+       orientation="-64,0"
+       id="guide4154" />
+    <sodipodi:guide
+       position="64,64.000069"
+       orientation="0,-64"
+       id="guide4156" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1058.5196)">
+    <path
+       id="path4249-5"
+       d="m 45,1115.5196 0,4 1,0 c 1.108,0 2,-0.892 2,-2 l 0,-2 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4255-6);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4251-7"
+       d="m 19,1115.5196 0,4 26,0 0,-4 z"
+       style="opacity:0.7;fill:url(#linearGradient4257-1);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4253-6"
+       d="m 16,1115.5196 0,2 c 0,1.108 0.892,2 2,2 l 1,0 0,-4 -3,0 z"
+       style="opacity:0.7;fill:url(#radialGradient4259-4);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="rect4159"
+       width="32"
+       height="52.999931"
+       x="16"
+       y="1064.5197"
+       ry="2.9999466" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="rect4355"
+       width="6"
+       height="0.99994665"
+       x="29"
+       y="1067.5198"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4215"
+       width="30"
+       height="51.000053"
+       x="17"
+       y="1065.5197"
+       ry="1.9999467" />
+    <rect
+       style="opacity:1;fill:#37474f;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4204"
+       width="28"
+       height="41.999825"
+       x="18"
+       y="1070.5198"
+       ry="0" />
+    <rect
+       style="opacity:1;fill:#81d4fa;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4369"
+       width="26"
+       height="39.999825"
+       x="19"
+       y="1071.5198" />
+    <rect
+       ry="1.0001488"
+       y="1113.5197"
+       x="30"
+       height="2.0002975"
+       width="4"
+       id="rect4209"
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501" />
+    <circle
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4211"
+       cx="40"
+       cy="1068.5198"
+       r="1" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4213"
+       width="2"
+       height="1"
+       x="22"
+       y="1068.5198" />
+    <rect
+       style="opacity:1;fill:#263238;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4217"
+       width="6"
+       height="2.0000534"
+       x="29"
+       y="1067.5198"
+       ry="1.0000267" />
+    <path
+       style="fill:#4db6ac;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 34,1084.5196 -7,1 -5,7 -3,2 0,13 26,0 0,-6 -3,-3 -2,-7 -6,-7 z"
+       id="path4349"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#009688;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 19,1102.2696 0,7.25 9,0 -3,-4 -5,-3 -1,-0.25 z"
+       id="path4351"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4353"
+       d="m 34,1084.5196 -2,1 -1,3 2,1 1,2 0,3 2,2 3,0 2,4 1,0 2,1 1,0 -3,-3 -2,-7 -6,-7 z"
+       style="fill:#80cbc4;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#26a69a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 25,1100.5196 -2,1 -1,1 -1,1 0.923828,0.4609 -2.923828,3.2891 0,2.25 26,0 0,-9 -4,3 -2,3 -4,1 -2,-2 -4,-2 -4,-3 z"
+       id="path4355"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#00897b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 24,1104.5196 -5,0.834 0,6.166 17,0 -3,-1 -3,-3 -6,-3 z"
+       id="path4357"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#009688;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 39,1102.5196 -3,2 c 0,0 -2,3 -3,4 -1,1 -4,2 -4,2 l 0.5,1 15.5,0 0,-8 c 0,0 -2,-1 -3,-1 l -3,0 z"
+       id="path4359"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#00695c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 31,1097.5196 -3,5 -6,4 -3,3 0,2 26,0 0,-5 -2,-1 -6,-7 -6,-1 z"
+       id="path4361"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#26a69a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 19,1102.2696 0,2.25 2,0 0.539062,-1.0762 L 20,1102.5196 l -1,-0.25 z"
+       id="path4363"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#00796b;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 37,1098.5196 -2,3 1,2 2,2 0,1 1,2 2,1 2,1 0.666016,1 1.333984,0 0,-5 -2,-1 -6,-7 z"
+       id="path4365"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:url(#linearGradient4184);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4176"
+       width="24"
+       height="2.0000534"
+       x="20"
+       y="1077.5197" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="rect4244"
+       width="24"
+       height="3.9999466"
+       x="20"
+       y="1074.5197" />
+    <circle
+       style="opacity:1;fill:#666666;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="path4246"
+       cx="41.999985"
+       cy="1076.5194"
+       r="1" />
+    <ellipse
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="path4248"
+       cx="32"
+       cy="1109.5194"
+       rx="1"
+       ry="1.0000153" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26,1110.5196 -2,-1 2,-1 z"
+       id="path4252"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.29943501"
+       id="rect4254"
+       width="2"
+       height="2.0000305"
+       x="38"
+       y="1108.5194" />
+  </g>
+</svg>

--- a/Lüv Dark/emblems/22/emblem-encrypted-locked.svg
+++ b/Lüv Dark/emblems/22/emblem-encrypted-locked.svg
@@ -1,0 +1,1 @@
+emblem-locked.svg

--- a/Lüv Dark/emblems/22/emblem-encrypted-unlocked.svg
+++ b/Lüv Dark/emblems/22/emblem-encrypted-unlocked.svg
@@ -1,0 +1,1 @@
+emblem-unlocked.svg

--- a/Lüv Dark/emblems/22/emblem-locked.svg
+++ b/Lüv Dark/emblems/22/emblem-locked.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg4359"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="emblem-locked.svg"
+   viewBox="0 0 22 22">
+  <defs
+     id="defs4361">
+    <radialGradient
+       gradientTransform="translate(0,6.1e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4157"
+       id="radialGradient4163"
+       cx="11"
+       cy="39"
+       fx="11"
+       fy="39"
+       r="8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4157">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4159" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4161" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="13.313812"
+     inkscape:cy="12.671927"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="963"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4105" />
+    <sodipodi:guide
+       position="0,22"
+       orientation="22,0"
+       id="guide4111" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,22"
+       id="guide4113" />
+    <sodipodi:guide
+       position="22,0"
+       orientation="-22,0"
+       id="guide4115" />
+    <sodipodi:guide
+       position="11,10"
+       orientation="16,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="12,11"
+       orientation="0,16"
+       id="guide4132" />
+    <sodipodi:guide
+       position="19,19"
+       orientation="0,-16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="3,22"
+       orientation="19.000011,0"
+       id="guide4152" />
+    <sodipodi:guide
+       position="3,2.9999886"
+       orientation="0,4"
+       id="guide4154" />
+    <sodipodi:guide
+       position="15,3"
+       orientation="0,4.0000019"
+       id="guide4162" />
+    <sodipodi:guide
+       position="19.000002,3"
+       orientation="-19,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="19.000002,22"
+       orientation="0,-4.0000019"
+       id="guide4166" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4364">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,-26)">
+    <circle
+       r="8"
+       cy="38.999992"
+       cx="11"
+       id="circle4155"
+       style="opacity:1;fill:url(#radialGradient4163);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#fbc02d;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4151"
+       cx="11"
+       cy="36.999992"
+       r="8" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fbc02d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147"
+       width="2"
+       height="2"
+       x="-2"
+       y="28" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fff9c4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147-8"
+       width="2"
+       height="2"
+       x="-2"
+       y="26" />
+    <path
+       style="opacity:1;fill:#fff9c4;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 11,6 C 9.338,6 8,7.338 8,9 l 0,2 -1,0 0,1 0,3 c 0,0.554 0.446,1 1,1 l 6,0 c 0.554,0 0.988922,-0.446111 1,-1 l 0,-3 0,-1 -1,0 0,-2 C 14,7.338 12.662,6 11,6 Z m 0,1 c 1.108,0 2,0.892 2,2 l 0,2 -4,0 0,-2 C 9,7.892 9.892,7 11,7 Z m -3,5 6,0 0,0.5 0,0.5 0,1.5 c 0,0.277 -0.223,0.5 -0.5,0.5 l -5,0 C 8.223,15 8,14.777 8,14.5 L 8,13 8,12.5 Z"
+       id="path4168"
+       transform="translate(0,26)"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccsssccccssssccssccccssssccc" />
+  </g>
+</svg>

--- a/Lüv Dark/emblems/22/emblem-nowrite.svg
+++ b/Lüv Dark/emblems/22/emblem-nowrite.svg
@@ -1,0 +1,1 @@
+emblem-locked.svg

--- a/Lüv Dark/emblems/22/emblem-readonly.svg
+++ b/Lüv Dark/emblems/22/emblem-readonly.svg
@@ -1,0 +1,1 @@
+emblem-locked.svg

--- a/Lüv Dark/emblems/22/emblem-symbolic-link.svg
+++ b/Lüv Dark/emblems/22/emblem-symbolic-link.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg4359"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="emblem-symbolic-link.svg"
+   viewBox="0 0 22 22">
+  <defs
+     id="defs4361">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4157">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4159" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4161" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4157"
+       id="radialGradient4163"
+       cx="11"
+       cy="39"
+       fx="11"
+       fy="39"
+       r="8"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32.526912"
+     inkscape:cx="16.652386"
+     inkscape:cy="10.101822"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="963"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4105" />
+    <sodipodi:guide
+       position="0,22"
+       orientation="22,0"
+       id="guide4111" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,22"
+       id="guide4113" />
+    <sodipodi:guide
+       position="22,0"
+       orientation="-22,0"
+       id="guide4115" />
+    <sodipodi:guide
+       position="11,10"
+       orientation="16,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="9,11"
+       orientation="0,16"
+       id="guide4132" />
+    <sodipodi:guide
+       position="19,19"
+       orientation="0,-16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="3,22"
+       orientation="19.000011,0"
+       id="guide4152" />
+    <sodipodi:guide
+       position="3,2.9999886"
+       orientation="0,4"
+       id="guide4154" />
+    <sodipodi:guide
+       position="15,3"
+       orientation="0,4.0000019"
+       id="guide4162" />
+    <sodipodi:guide
+       position="19.000002,3"
+       orientation="-19,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="19.000002,22"
+       orientation="0,-4.0000019"
+       id="guide4166" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4364">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,-26)">
+    <circle
+       r="8"
+       cy="39"
+       cx="11"
+       id="circle4155"
+       style="opacity:1;fill:url(#radialGradient4163);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#455a64;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4151"
+       cx="11"
+       cy="37"
+       r="8" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#455a64;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147"
+       width="2"
+       height="2"
+       x="-2"
+       y="26" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f5f5f5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147-5"
+       width="2"
+       height="2"
+       x="-2"
+       y="28" />
+    <path
+       style="opacity:1;fill:#f5f5f5;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6 9 C 5.446 9 5 9.446 5 10 L 5 12 C 5 12.554 5.446 13 6 13 L 9 13 C 9.554 13 10 12.554 10 12 L 12 12 C 12 12.554 12.446 13 13 13 L 16 13 C 16.554 13 17 12.554 17 12 L 17 10 C 17 9.446 16.554 9 16 9 L 13 9 C 12.446 9 12 9.446 12 10 L 10 10 C 10 9.446 9.554 9 9 9 L 6 9 z M 6 10 L 9 10 L 9 12 L 6 12 L 6 10 z M 13 10 L 16 10 L 16 12 L 13 12 L 13 10 z "
+       transform="translate(0,26)"
+       id="rect4165" />
+  </g>
+</svg>

--- a/Lüv Dark/emblems/22/emblem-unlocked.svg
+++ b/Lüv Dark/emblems/22/emblem-unlocked.svg
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg4359"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="emblem-unlocked.svg"
+   viewBox="0 0 22 22">
+  <defs
+     id="defs4361">
+    <radialGradient
+       gradientTransform="translate(0,6.1e-6)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4157"
+       id="radialGradient4163"
+       cx="11"
+       cy="39"
+       fx="11"
+       fy="39"
+       r="8"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4157">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4159" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4161" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.58767"
+     inkscape:cy="15.016769"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="963"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4105" />
+    <sodipodi:guide
+       position="0,22"
+       orientation="22,0"
+       id="guide4111" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="0,22"
+       id="guide4113" />
+    <sodipodi:guide
+       position="22,0"
+       orientation="-22,0"
+       id="guide4115" />
+    <sodipodi:guide
+       position="11,10"
+       orientation="16,0"
+       id="guide4130" />
+    <sodipodi:guide
+       position="12,11"
+       orientation="0,16"
+       id="guide4132" />
+    <sodipodi:guide
+       position="19,19"
+       orientation="0,-16"
+       id="guide4136" />
+    <sodipodi:guide
+       position="3,22"
+       orientation="19.000011,0"
+       id="guide4152" />
+    <sodipodi:guide
+       position="3,2.9999886"
+       orientation="0,4"
+       id="guide4154" />
+    <sodipodi:guide
+       position="15,3"
+       orientation="0,4.0000019"
+       id="guide4162" />
+    <sodipodi:guide
+       position="19.000002,3"
+       orientation="-19,0"
+       id="guide4164" />
+    <sodipodi:guide
+       position="19.000002,22"
+       orientation="0,-4.0000019"
+       id="guide4166" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4364">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,-26)">
+    <circle
+       r="8"
+       cy="38.999992"
+       cx="11"
+       id="circle4155"
+       style="opacity:1;fill:url(#radialGradient4163);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#512da8;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4151"
+       cx="11"
+       cy="36.999992"
+       r="8" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#512da8;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147"
+       width="2"
+       height="2"
+       x="-2"
+       y="28" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#d1c4e9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4147-8"
+       width="2"
+       height="2"
+       x="-2"
+       y="26" />
+    <path
+       style="opacity:1;fill:#d1c4e9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11 6 C 9.3721716 6 8.0632345 7.2860313 8.0097656 8.9003906 L 8 8.9003906 L 8 9 L 8 9.5 A 0.5 0.5 0 0 0 8.5 10 A 0.5 0.5 0 0 0 9 9.5 L 9 9 C 9 7.892 9.892 7 11 7 C 12.108 7 13 7.892 13 9 L 13 11 L 14 11 L 14 9 C 14 7.338 12.662 6 11 6 z "
+       id="rect4289"
+       transform="translate(0,26)" />
+    <path
+       style="opacity:1;fill:#d1c4e9;fill-opacity:1;stroke:none;stroke-width:0.1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7 11 L 7 12 L 7 15 C 7 15.554 7.446 16 8 16 L 14 16 C 14.554 16 14.988922 15.553889 15 15 L 15 12 L 15 11 L 14 11 L 13 11 L 8 11 L 7 11 z M 8 12 L 14 12 L 14 12.5 L 14 13 L 14 14.5 C 14 14.777 13.777 15 13.5 15 L 8.5 15 C 8.223 15 8 14.777 8 14.5 L 8 13 L 8 12.5 L 8 12 z "
+       transform="translate(0,26)"
+       id="path4168" />
+  </g>
+</svg>

--- a/Lüv Dark/emblems/8/emblem-mounted.svg
+++ b/Lüv Dark/emblems/8/emblem-mounted.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   viewBox="0 0 2.1166666 2.1166667"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="emblem-mounted.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="69.650018"
+     inkscape:cx="3.2799808"
+     inkscape:cy="4.3034419"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="957"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4141" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-294.88332)">
+    <path
+       style="opacity:1;fill:#2980b9;fill-opacity:1;stroke:none;stroke-width:0.02645833;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 2.1166666,295.67707 -0.2645833,0 0,-0.26458 -1.32291664,0 0,0.26458 -0.52916666,0 0,0.52917 0.52916666,0 0,0.26458 1.32291664,0 0,-0.26458 0.2645833,0 0,-0.52917 z m -0.5291666,0 0,0.52917 -0.2645833,0 -10e-8,-0.52917 0.2645834,0 z"
+       id="rect4166"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;fill:#2980b9;fill-opacity:1;stroke:none;stroke-width:0.02645833;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4210"
+       width="0.52916664"
+       height="0.52916664"
+       x="-0.52916664"
+       y="294.88333" />
+  </g>
+</svg>

--- a/Lüv Dark/emblems/8/emblem-unmounted.svg
+++ b/Lüv Dark/emblems/8/emblem-unmounted.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   viewBox="0 0 2.1166666 2.1166667"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="emblem-unmounted.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="49.25"
+     inkscape:cx="-3.691594"
+     inkscape:cy="5.3051867"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="957"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4141" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-294.88332)">
+    <path
+       style="opacity:1;fill:#d24d57;fill-opacity:1;stroke:none;stroke-width:0.09999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 0 3 L 0 6 L 1 6 L 1 8 L 3 8 L 3 6 L 4 6 L 4 5 L 4 4 L 4 3 L 2 3 L 1 3 L 0 3 z M 1 4 L 2 4 L 3 4 L 3 5 L 2 5 L 1 5 L 1 4 z "
+       transform="matrix(0.26458333,0,0,0.26458333,0,294.88332)"
+       id="rect4166" />
+    <rect
+       style="opacity:1;fill:#d24d57;fill-opacity:1;stroke:none;stroke-width:0.02645833;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect4210"
+       width="0.52916664"
+       height="0.52916664"
+       x="-0.52916664"
+       y="294.88333" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-documents-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-documents-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-documents-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="38.417673"
+     inkscape:cx="2.1528582"
+     inkscape:cy="5.8016142"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 13,1050.3622 0,-12 -5,0 -1,0 -1,0 -3,3 0,1 0,1 0,7 10,0 z m -1,-1 -8,0 0,-6 0,-1 3,0 0,-3 1,0 4,0 0,10 z"
+       id="path4142"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-download-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-download-symbolic.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-download-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.560553"
+     inkscape:cx="-101.03206"
+     inkscape:cy="-1055.3128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 6,2 6,3 6,7 4,7 4,7.9980469 4,8 4,8.0078125 7.9902344,12 8,12 8.0097656,12 12,8.0078125 12,8 12,7 10,7 10,3 10,2 Z M 7,3 9,3 9,8 10,8 10.59375,8 8,10.59375 5.40625,8 7,8 7,7 Z m -5,8 0,3 1,0 11,0 0,-1 0,-2 -1,0 0,2 -10,0 0,-2 z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-music-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-music-symbolic.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-music-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="54.88239"
+     inkscape:cx="4.1497969"
+     inkscape:cy="6.0174804"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 5,2 0,1 0,1 0,1 0,5.275391 C 4.7049987,10.104291 4.3669301,10 4,10 c -1.108,0 -2,0.892 -2,2 0,1.108 0.892,2 2,2 1.108,0 2,-0.892 2,-2 l 0,-6 0,-1 7,0 0,1 0,4.275391 C 12.704999,10.104291 12.36693,10 12,10 c -1.108,0 -2,0.892 -2,2 0,1.108 0.892,2 2,2 1.108,0 2,-0.892 2,-2 L 14,2 Z m 1,1 7,0 0,1 -7,0 z"
+       transform="translate(0,1036.3622)"
+       id="rect4197"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccsssscccccssssccccccc" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-pictures-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-pictures-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-pictures-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="0.5421157"
+     inkscape:cy="7.6289719"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 7 2 L 7 3 L 7 4 L 5 4 L 5 3 L 3 3 L 3 4 L 1 4 L 1 14 L 15 14 L 15 4 L 13 4 L 13 3 L 13 2 L 12 2 L 8 2 L 7 2 z M 8 3 L 12 3 L 12 4 L 8 4 L 8 3 z M 2 5 L 14 5 L 14 13 L 2 13 L 2 5 z M 8 6 C 6.338 6 5 7.338 5 9 C 5 10.662 6.338 12 8 12 C 9.662 12 11 10.662 11 9 C 11 7.338 9.662 6 8 6 z M 8 7 C 9.108 7 10 7.892 10 9 C 10 10.108 9.108 11 8 11 C 6.892 11 6 10.108 6 9 C 6 7.892 6.892 7 8 7 z "
+       transform="translate(0,1036.3622)"
+       id="rect4206" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-publicshare-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-publicshare-symbolic.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-publicshare-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.893096"
+     inkscape:cx="-0.095954343"
+     inkscape:cy="7.426566"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 7.9902344,2 4,5.9921875 4,6.0019531 4,7 l 2,0 0,2.999 0,1 4,0.002 0,-1 0,-2.9989999 2,0 0,-1 0,-0.00977 L 8.0097656,2 8,2 Z M 8,3.40625 10.59375,6 10,6 9,6 9,9.999 7,9.999 7,7 7,6 5.40625,6 Z M 3,9 l 0,1 0,4 1,0 9,0 0,-1 0,-4 -1,0 -1,0 0,1 1,0 0,3 -8,0 0,-3 1,0 0,-1 -1,0 z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-remote-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-remote-symbolic.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-remote-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.73689"
+     inkscape:cx="-14.497649"
+     inkscape:cy="5.4206954"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 3,2 0,2 0,1 -1,0 0,6 4,0 0,1 -4,0 0,1 4,0 0,1 4,0 0,-1 4,0 0,-1 -4,0 0,-1 4,0 0,-6 -1,0 0,-2 -4.3535156,0 C 8.2675541,2.4456 7.6351043,2 7,2 Z m 1,2 5,0 3,0 0,1 -8,0 z m 3,8 2,0 0,1 -2,0 z"
+       transform="translate(0,1036.3622)"
+       id="rect4197"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccscccccccccccc" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-saved-search-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-saved-search-symbolic.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-saved-search-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="17.0625"
+     inkscape:cx="-5.6046749"
+     inkscape:cy="10.151631"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4137" />
+    <sodipodi:guide
+       position="0,16.000017"
+       orientation="16,0"
+       id="guide4145" />
+    <sodipodi:guide
+       position="0,1.7382813e-05"
+       orientation="0,16"
+       id="guide4147" />
+    <sodipodi:guide
+       position="16,1.7382813e-05"
+       orientation="-16,0"
+       id="guide4149" />
+    <sodipodi:guide
+       position="16,16.000017"
+       orientation="0,-16"
+       id="guide4151" />
+    <sodipodi:guide
+       position="1,1.0000174"
+       orientation="0,14"
+       id="guide4155" />
+    <sodipodi:guide
+       position="15,1.0000174"
+       orientation="-14,0"
+       id="guide4157" />
+    <sodipodi:guide
+       position="15,15.000017"
+       orientation="0,-14"
+       id="guide4159" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4161" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4163" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4165" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4167" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 6 2 C 3.7839952 2 2 3.7839952 2 6 C 2 8.2160048 3.7839952 10 6 10 C 6.926351 10 7.7667544 9.675125 8.4433594 9.1503906 L 13.292969 14 L 14 13.292969 L 9.1503906 8.4433594 C 9.675125 7.7667544 10 6.926351 10 6 C 10 3.7839952 8.2160048 2 6 2 z M 6 3 C 7.6620073 3 9 4.3379927 9 6 C 9 6.6493939 8.7914132 7.246354 8.4433594 7.7363281 C 8.4243114 7.763143 8.3988056 7.7844006 8.3789062 7.8105469 C 8.2155621 8.0252113 8.0252113 8.2155621 7.8105469 8.3789062 C 7.7843927 8.3988077 7.7631759 8.424288 7.7363281 8.4433594 C 7.246354 8.7914132 6.6493939 9 6 9 C 4.3379927 9 3 7.6620073 3 6 C 3 4.3379927 4.3379927 3 6 3 z "
+       transform="translate(0,1036.3622)"
+       id="rect4179" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="36.025364"
+     inkscape:cx="0.68827834"
+     inkscape:cy="8.4094505"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 2,2 2,4 2,5 1,5 1,14 15,14 15,5 14,5 14,3 8.6464844,3 C 8.2675541,2.4456398 7.6351043,2 7,2 L 2,2 Z M 3,4 9,4 13,4 13,5 3,5 3,4 Z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-templates-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-templates-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-templates-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="40.968847"
+     inkscape:cx="3.8212508"
+     inkscape:cy="7.2000736"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 6 2 L 3 5 L 3 6 L 3 7 L 3 14 L 7 14 L 7 13 L 4 13 L 4 7 L 4 6 L 7 6 L 7 3 L 8 3 L 12 3 L 12 6 L 13 6 L 13 2 L 8 2 L 7 2 L 6 2 z M 12 6 L 11 6 L 11 7 L 12 7 L 12 6 z M 12 7 L 12 8 L 13 8 L 13 7 L 12 7 z M 12 8 L 11 8 L 11 9 L 12 9 L 12 8 z M 12 9 L 12 10 L 13 10 L 13 9 L 12 9 z M 12 10 L 11 10 L 11 11 L 12 11 L 12 10 z M 12 11 L 12 12 L 13 12 L 13 11 L 12 11 z M 12 12 L 11 12 L 11 13 L 12 13 L 12 12 z M 12 13 L 12 14 L 13 14 L 13 13 L 12 13 z M 11 13 L 10 13 L 10 14 L 11 14 L 11 13 z M 10 13 L 10 12 L 9 12 L 9 13 L 10 13 z M 9 13 L 8 13 L 8 14 L 9 14 L 9 13 z M 8 13 L 8 12 L 7 12 L 7 13 L 8 13 z "
+       transform="translate(0,1036.3622)"
+       id="path4142" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/folder-videos-symbolic.svg
+++ b/Lüv Dark/places/symbolic/folder-videos-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="folder-videos-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.465324"
+     inkscape:cx="2.1113108"
+     inkscape:cy="8.381214"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 2,2 2,14 14,14 14,2 2,2 Z M 3,3 5,3 5,5 3,5 3,3 Z m 3,0 4,0 0,5 -4,0 0,-5 z m 5,0 2,0 0,2 -2,0 0,-2 z M 3,7 5,7 5,9 3,9 3,7 Z m 8,0 2,0 0,2 -2,0 0,-2 z m -5,2 4,0 0,4 -4,0 0,-4 z m -3,2 2,0 0,2 -2,0 0,-2 z m 8,0 2,0 0,2 -2,0 0,-2 z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/network-server-symbolic.svg
+++ b/Lüv Dark/places/symbolic/network-server-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="network-server-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.465324"
+     inkscape:cx="2.7870005"
+     inkscape:cy="6.9674073"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 2 2 L 2 5 L 2 6 L 2 9 L 2 11 L 3 11 L 6 11 L 6 12 L 2 12 L 2 13 L 6 13 L 6 14 L 10 14 L 10 13 L 14 13 L 14 12 L 10 12 L 10 11 L 13 11 L 14 11 L 14 10 L 14 5 L 14 2 L 2 2 z M 11.5 3 C 11.777 3 12 3.223 12 3.5 C 12 3.777 11.777 4 11.5 4 C 11.223 4 11 3.777 11 3.5 C 11 3.223 11.223 3 11.5 3 z M 3 5 L 7 5 L 9 5 L 13 5 L 13 6 L 3 6 L 3 5 z M 11.5 7 C 11.777 7 12 7.223 12 7.5 C 12 7.777 11.777 8 11.5 8 C 11.223 8 11 7.777 11 7.5 C 11 7.223 11.223 7 11.5 7 z M 3 9 L 13 9 L 13 10 L 3 10 L 3 9 z M 7 12 L 9 12 L 9 13 L 7 13 L 7 12 z "
+       transform="translate(0,1036.3622)"
+       id="rect4197" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/network-workgroup-symbolic.svg
+++ b/Lüv Dark/places/symbolic/network-workgroup-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="network-workgroup-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.465324"
+     inkscape:cx="4.9489997"
+     inkscape:cy="7.9016045"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 2 2 L 2 5 L 7 5 L 7 11 L 6 11 L 6 12 L 2 12 L 2 13 L 6 13 L 6 14 L 10 14 L 10 13 L 14 13 L 14 12 L 10 12 L 10 11 L 9 11 L 9 5 L 14 5 L 14 2 L 2 2 z M 12.5 3 C 12.777 3 13 3.223 13 3.5 C 13 3.777 12.777 4 12.5 4 C 12.223 4 12 3.777 12 3.5 C 12 3.223 12.223 3 12.5 3 z M 7 12 L 9 12 L 9 13 L 7 13 L 7 12 z "
+       transform="translate(0,1036.3622)"
+       id="rect4197" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/user-desktop-symbolic.svg
+++ b/Lüv Dark/places/symbolic/user-desktop-symbolic.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="user-desktop-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="37.465324"
+     inkscape:cx="3.6144323"
+     inkscape:cy="7.9282958"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="opacity:1;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1 2 L 1 14 L 15 14 L 15 2 L 1 2 z M 2 3 L 14 3 L 14 11 L 2 11 L 2 3 z M 3 4 L 3 7 L 7 7 L 7 5 L 6 5 C 6 5 6 4 5 4 L 3 4 z M 2 12 L 3 12 L 3 13 L 2 13 L 2 12 z M 4 12 L 10 12 L 10 13 L 4 13 L 4 12 z M 11 12 L 12 12 L 12 13 L 11 13 L 11 12 z M 13 12 L 14 12 L 14 13 L 13 13 L 13 12 z "
+       transform="translate(0,1036.3622)"
+       id="rect4144" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/user-home-symbolic.svg
+++ b/Lüv Dark/places/symbolic/user-home-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="user-home-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.132318"
+     inkscape:cx="-0.16442108"
+     inkscape:cy="10.066159"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 6,1038.3622 0,1.7109 2,-1.6953 6,5.086 -0.646484,0.7636 L 8,1039.6884 2.646484,1044.2274 2,1043.4638 l 3,-2.543 0,-2.5586 z m 7,4.5 0,7.5 -1,0 -3,0 -2,0 -4,0 0,-1 0,-6.5 1,0 0,6.5 3,0 0,-4 2,0 0,4 3,0 0,-6.5 z"
+       id="folderGlyph"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccc" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/user-trash-full-symbolic.svg
+++ b/Lüv Dark/places/symbolic/user-trash-full-symbolic.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="user-trash-full-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="39.953255"
+     inkscape:cx="2.7090907"
+     inkscape:cy="7.7463358"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dc322f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 6,2 -1,1 0,2 -2,0 0,1 0,1 1,0 0,7 8,0 0,-7 1,0 0,-1 0,-1 -2,0 0,-2 -1,-1 z m 0,1 4,0 0,1 0,1 -4,0 0,-1 z m 0,4 1,0 0,6 -1,0 z m 3,0 1,0 0,6 -1,0 z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccc" />
+    <g
+       transform="translate(-19.710179,1011.5327)"
+       inkscape:label="Layer 1"
+       id="layer1-3" />
+  </g>
+</svg>

--- a/Lüv Dark/places/symbolic/user-trash-symbolic.svg
+++ b/Lüv Dark/places/symbolic/user-trash-symbolic.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   viewBox="0 0 16 16"
+   sodipodi:docname="user-trash-symbolic.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="52.983969"
+     inkscape:cx="5.9353274"
+     inkscape:cy="11.191083"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:showpageshadow="false"
+     borderlayer="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="670"
+     inkscape:window-x="-4"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     units="px"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4101" />
+    <sodipodi:guide
+       position="2,14.000017"
+       orientation="12,0"
+       id="guide4071" />
+    <sodipodi:guide
+       position="2,2.0000174"
+       orientation="0,12"
+       id="guide4073" />
+    <sodipodi:guide
+       position="14,2.0000174"
+       orientation="-12,0"
+       id="guide4075" />
+    <sodipodi:guide
+       position="14,14.000017"
+       orientation="0,-12"
+       id="guide4077" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 6,2 -1,1 0,2 -2,0 0,1 0,1 1,0 0,7 8,0 0,-7 1,0 0,-1 0,-1 -2,0 0,-2 -1,-1 z m 0,1 4,0 0,1 0,1 -4,0 0,-1 z m 0,4 1,0 0,6 -1,0 z m 3,0 1,0 0,6 -1,0 z"
+       transform="translate(0,1036.3622)"
+       id="folderGlyph"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
There are many icons missing from Lüv Dark. I assume this is because there are Lüv Dark specific icons coming later but for now Lüv Dark is unusable as a result.

I solved this issue by merging all the extra icons from Lüv into Lüv Dark. I skipped some extra battery icons that were obviously the wrong colors but otherwise the regular Lüv icons seem to be a fine substitute to get it working for dark theme users.

I've been a fan of Flattr and now Lüv for a while and I look forward to seeing this further developed! Thanks!